### PR TITLE
fix(positioning): 删冗余字段 + 海外背景双 GPA 强制必填

### DIFF
--- a/src/lib/positioning/profile-schema.js
+++ b/src/lib/positioning/profile-schema.js
@@ -41,14 +41,18 @@ export const FIELD_DEFINITIONS = [
     type: 'number',
     required: true,
     label: { 'zh-Hans': 'GPA', en: 'GPA' },
+    labelOverride: (p) => (p && (p.ugType === 'cn-joint-venture' || p.ugType === 'cn-transfer-us'))
+      ? { 'zh-Hans': '陆本 GPA', en: 'CN-portion GPA' }
+      : null,
     min: 0, max: 100, step: 0.01,
   },
   {
     key: 'jointForeignGpa',
     type: 'number',
     required: false,
-    label: { 'zh-Hans': '海外段 GPA', en: 'Foreign-portion GPA' },
-    help: { 'zh-Hans': '中外合办 / 转学美本的海外段 GPA', en: 'GPA of the overseas portion (joint venture or US transfer)' },
+    requiredIf: (p) => p && (p.ugType === 'cn-joint-venture' || p.ugType === 'cn-transfer-us'),
+    label: { 'zh-Hans': '海外 GPA', en: 'Overseas GPA' },
+    help: { 'zh-Hans': '中外合办海外段 / 转学美本的 GPA', en: 'Overseas portion GPA (joint venture or US transfer)' },
     min: 0, max: 100, step: 0.01,
     showIf: (p) => p && (p.ugType === 'cn-joint-venture' || p.ugType === 'cn-transfer-us'),
   },
@@ -56,7 +60,8 @@ export const FIELD_DEFINITIONS = [
     key: 'jointForeignGpaScale',
     type: 'select',
     required: false,
-    label: { 'zh-Hans': '海外段 GPA 制式', en: 'Foreign-portion GPA scale' },
+    requiredIf: (p) => p && (p.ugType === 'cn-joint-venture' || p.ugType === 'cn-transfer-us'),
+    label: { 'zh-Hans': '海外 GPA 制式', en: 'Overseas GPA scale' },
     options: [
       { value: '4.0', label: { 'zh-Hans': '4.0 制', en: '4.0 scale' } },
       { value: '4.3', label: { 'zh-Hans': '4.3 制', en: '4.3 scale' } },

--- a/src/lib/positioning/profile-schema.js
+++ b/src/lib/positioning/profile-schema.js
@@ -89,14 +89,6 @@ export const FIELD_DEFINITIONS = [
     showIf: (p) => p && p.major !== 'cs',
   },
   {
-    key: 'csCoursesTakenCount',
-    type: 'number',
-    required: false,
-    label: { 'zh-Hans': '已修 CS 课程总数', en: 'Total CS courses taken' },
-    min: 0, max: 50, step: 1,
-    showIf: (p) => p && p.major !== 'cs',
-  },
-  {
     key: 'toefl',
     type: 'number',
     required: false,

--- a/src/pages/school-positioning.jsx
+++ b/src/pages/school-positioning.jsx
@@ -102,8 +102,21 @@ function getGpaBounds(profile) {
   return { min: 0, max: 4 };
 }
 
+function isRequired(f, profile) {
+  if (typeof f.requiredIf === 'function') return !!f.requiredIf(profile);
+  return !!f.required;
+}
+
+function resolveLabel(f, profile) {
+  if (typeof f.labelOverride === 'function') {
+    const override = f.labelOverride(profile);
+    if (override) return override;
+  }
+  return f.label;
+}
+
 function validateOne(f, v, profile, t) {
-  if (f.required) {
+  if (isRequired(f, profile)) {
     const empty = v === '' || v === null || v === undefined;
     if (empty) return t.fillRequired;
   }
@@ -299,7 +312,8 @@ function FormBody() {
   };
 
   const renderField = (f) => {
-    const label = getLabel(f.label, locale);
+    const label = getLabel(resolveLabel(f, profile), locale);
+    const required = isRequired(f, profile);
     const help = f.help ? getLabel(f.help, locale) : '';
     const errKey = touched ? errors[f.key] : undefined;
     const hasErr = Boolean(errKey);
@@ -312,7 +326,7 @@ function FormBody() {
         <div key={f.key} className={styles.field} style={{ gridColumn: '1 / -1' }}>
           <label className={styles.label}>
             {label}
-            {f.required && <span className={styles.required}>*</span>}
+            {required && <span className={styles.required}>*</span>}
           </label>
           {help && <div className={styles.help} style={{ marginTop: 0, marginBottom: 8 }}>{help}</div>}
           <div className={styles.grid}>
@@ -358,7 +372,7 @@ function FormBody() {
             />
             <label htmlFor={`f-${f.key}`} className={styles.checkboxLabel}>
               {label}
-              {f.required && <span className={styles.required}>*</span>}
+              {required && <span className={styles.required}>*</span>}
             </label>
           </div>
           {help && <div className={styles.help}>{help}</div>}
@@ -372,7 +386,7 @@ function FormBody() {
         <div key={f.key} className={styles.field}>
           <label htmlFor={`f-${f.key}`} className={styles.label}>
             {label}
-            {f.required && <span className={styles.required}>*</span>}
+            {required && <span className={styles.required}>*</span>}
           </label>
           <select
             id={`f-${f.key}`}
@@ -397,7 +411,7 @@ function FormBody() {
         <div key={f.key} className={styles.field}>
           <label htmlFor={`f-${f.key}`} className={styles.label}>
             {label}
-            {f.required && <span className={styles.required}>*</span>}
+            {required && <span className={styles.required}>*</span>}
           </label>
           {renderNumberInput(f, profile[f.key], (v) => setValue(f.key, v), hasErr)}
           {help && <div className={styles.help}>{help}</div>}
@@ -410,7 +424,7 @@ function FormBody() {
       <div key={f.key} className={styles.field}>
         <label htmlFor={`f-${f.key}`} className={styles.label}>
           {label}
-          {f.required && <span className={styles.required}>*</span>}
+          {required && <span className={styles.required}>*</span>}
         </label>
         <input
           id={`f-${f.key}`}


### PR DESCRIPTION
## Summary
基于 PR #217 之后的两轮反馈：

1. **删 \`csCoursesTakenCount\`**（已修 CS 课程总数）—— 跟 \`csCoursesCompleted\` 重复，且 backend classifier 实际没用这个字段
2. **海外背景 GPA 字段优化** —— 对于 \`ugType ∈ {cn-joint-venture, cn-transfer-us}\`：
   - 「GPA」label 动态显示为「陆本 GPA」
   - 「海外 GPA」+「海外 GPA 制式」从 optional 改成必填（之前容易漏填）
   - schema 引入 \`labelOverride(profile)\` + \`requiredIf(profile)\` 两种动态谓词

bigTechIntern 经讨论决定保留，跟实习段数（quantity）问的是不同的信号（quality）。

## Test plan
- [x] 本地 \`npm run build\` 通过
- [ ] 合入后 Actions Deploy Docusaurus 通过