### PR TITLE
chore(positioning): 价格 $19.99 → $29.99 (live 模式)

### DIFF
--- a/src/pages/school-positioning.jsx
+++ b/src/pages/school-positioning.jsx
@@ -6,8 +6,8 @@ import { FIELD_DEFINITIONS } from '@site/src/lib/positioning/profile-schema';
 import { WORKER_BASE_URL } from '@site/src/lib/positioning/api';
 import styles from './school-positioning.module.css';
 
-const PRICE_USD = 19.99;
-const PRICE_LABEL = '$19.99';
+const PRICE_USD = 29.99;
+const PRICE_LABEL = '$29.99';
 
 const COPY = {
   'zh-Hans': {


### PR DESCRIPTION
## Summary
- `PRICE_USD` 19.99 → 29.99，`PRICE_LABEL` 同步
- worker 端 `unit_amount` 已改成 2999 并部署（version 51961605）
- Stripe live secret key + webhook signing secret 已在 Cloudflare worker 配置
- /api/positioning/checkout 实测返回 `cs_live_...` session，确认 live 模式生效

## Test plan
- [x] worker 部署成功 + live key smoke test 通过
- [ ] 合入后 Actions 部署前端 → csgrad.com 显示 \$29.99
- [ ] 真实下单一次确认款项到账（生产验证）