### PR TITLE
feat(datapoints): /submit-dp + /my-dp 收尾页面

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -96,13 +96,21 @@ const config = {
             position: 'left',
             items: [
               {
-                type: 'doc',
-                docId: 'datapoints',
-                label: 'DataPoints (旧版/Seatable)',
+                to: '/datapoints-new',
+                label: '浏览 DataPoints',
               },
               {
-                to: '/datapoints-new',
-                label: 'DataPoints (新版 / beta)',
+                to: '/submit-dp',
+                label: '提交 DataPoints',
+              },
+              {
+                to: '/my-dp',
+                label: '我的 DataPoints',
+              },
+              {
+                type: 'doc',
+                docId: 'datapoints',
+                label: '旧版 (Seatable iframe)',
               },
               {
                 to: '/school-positioning',

--- a/src/lib/dp/api.js
+++ b/src/lib/dp/api.js
@@ -146,3 +146,51 @@ export async function getCounts() {
     return { applicants: 0, programs: 0, datapoints: 0 };
   }
 }
+
+// ---------- write APIs (require session) ----------
+
+async function jsonRequest(method, path, body) {
+  const r = await fetch(`${DP_API_BASE}${path}`, {
+    method,
+    credentials: 'include',
+    headers: body ? { 'Content-Type': 'application/json' } : {},
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  let data = null;
+  try { data = await r.json(); } catch {}
+  if (!r.ok) {
+    const msg = (data && (data.error || data.message)) || `HTTP ${r.status}`;
+    throw new Error(msg);
+  }
+  return data;
+}
+
+export const getMyApplicant = () => jsonRequest('GET', '/api/applicant/me');
+export const createMyApplicant = (body) => jsonRequest('POST', '/api/applicant/me', body);
+export const updateMyApplicant = (body) => jsonRequest('PATCH', '/api/applicant/me', body);
+
+export const createDp = (body) => jsonRequest('POST', '/api/dp', body);
+export const updateDp = (id, body) => jsonRequest('PATCH', `/api/dp/${id}`, body);
+export const deleteDp = (id) => jsonRequest('DELETE', `/api/dp/${id}`);
+
+// List the current user's own DPs. Backend's GET /api/dp doesn't filter by
+// user, so we hit it with no filters and post-filter by applicant_id == me.
+export async function listMyDp(applicantId) {
+  if (!applicantId) return { rows: [], total: 0 };
+  // Use a high limit; per-user DP count is typically < 30.
+  const url = buildUrl('/api/dp', { limit: 200 });
+  const r = await fetch(url, { credentials: 'include' });
+  if (!r.ok) throw new Error(`HTTP ${r.status}`);
+  const json = await r.json();
+  const mine = json.rows.filter((row) => row.a?.id === applicantId);
+  return { rows: mine, total: mine.length };
+}
+
+export async function signOut() {
+  try {
+    await fetch(`${DP_API_BASE}/api/auth/sign-out`, {
+      method: 'POST',
+      credentials: 'include',
+    });
+  } catch {}
+}

--- a/src/lib/dp/enums.js
+++ b/src/lib/dp/enums.js
@@ -1,0 +1,39 @@
+// Enum values for applicant + DP form fields. Mirrors the Seatable schema
+// so historical data renders consistently in the new form.
+
+export const UG_CATEGORIES = [
+  '中外合办校（XJTLU等）', '陆本中外合办院系（JI/ZJUI等）',
+  '清北', '华五', '国科/上科/南科', '10043', '985', '211',
+  '双非', '陆本', '美本', '加本', '英本', '澳本', '港本', '坡本', '欧陆本', '海本',
+];
+
+export const UG_MAJORS = [
+  'CS', 'SE', 'AI', 'DS', 'ECE', 'EE',
+  '自动化/Robotics', 'Info System', 'Info Security',
+  'CS交叉学科（bme等）', '其他电类学科（精仪等）',
+  'Math/Stat', '其他理工科', '其他学科',
+];
+
+export const CS_COURSES = [
+  '高等数学/微积分/数学分析', '离散数学', '线性代数', '概率论',
+  '程序设计', '数据结构', '操作系统', '计算机网络',
+  '体系结构/计算机组成', '软件工程', '数据库', '计算机科学导论',
+];
+
+export const GPA_SCALES = ['100', '4.0', '4.3', '5.0', '英制100', '德制1.0', '7', '其他'];
+export const GPA_RANKS = ['1%', '3%', '5%', '10%', '15%', '20%', '30%', '40%', '50%', '50%+'];
+
+export const REC_TAGS = [
+  '科研推', '实习推', '全职工作推', '课程推', 'TA推', '暑研推',
+  '黑推（提及缺点，或者量表评分给的太低，在30%甚至更低的推荐信）',
+  '平推（模板推，或整体积极，但和学生没有过多交集，学生的工作比较trivial，无法言之有物地表扬）',
+  '强推（和学生非常熟悉，言之有物地赞扬学生的工作；量表评分很高，评价为"该年最好"及以上）',
+  '普通推（admission officer大概率不认识该推荐人）',
+  '小牛推（小领域内较为知名的学者推荐，相同小领域的PhD学生和教授很可能认识该推荐人）',
+  '大牛推（大领域内较为知名的学者推荐，相同大领域的PhD学生和教授很可能认识该推荐人）',
+];
+
+export const REC_TAGS_WITH_NONE = ['无', ...REC_TAGS];
+
+export const RESULTS = ['Admit', 'Reject', 'Waitlist', '默拒', 'Withdraw'];
+export const SEMESTERS = ['Fall', 'Spring', 'Winter', 'Summer'];

--- a/src/pages/my-dp.jsx
+++ b/src/pages/my-dp.jsx
@@ -1,0 +1,275 @@
+import React, { useEffect, useState } from 'react';
+import Layout from '@theme/Layout';
+import BrowserOnly from '@docusaurus/BrowserOnly';
+import {
+  DP_API_BASE, getMe, getMyApplicant, listMyDp,
+  updateDp, deleteDp, signOut,
+} from '@site/src/lib/dp/api';
+import { RESULTS, SEMESTERS } from '@site/src/lib/dp/enums';
+import styles from './my-dp.module.css';
+
+function Inner() {
+  const [me, setMe] = useState(null);
+  const [meChecked, setMeChecked] = useState(false);
+  const [applicant, setApplicant] = useState(null);
+  const [rows, setRows] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [editing, setEditing] = useState(null); // dp id being edited
+  const [draft, setDraft] = useState(null);
+  const [msg, setMsg] = useState(null);
+
+  async function reload() {
+    setLoading(true);
+    setError(null);
+    try {
+      const meRes = await getMe();
+      setMe(meRes.user);
+      setMeChecked(true);
+      if (!meRes.user) return;
+      const ap = await getMyApplicant();
+      setApplicant(ap.applicant);
+      if (ap.applicant) {
+        const dpRes = await listMyDp(ap.applicant.id);
+        setRows(dpRes.rows);
+      }
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => { reload(); }, []);
+
+  if (!meChecked) return <div className={styles.loading}>加载中…</div>;
+  if (!me) {
+    return (
+      <div className={styles.gate}>
+        <h2>需要登录</h2>
+        <p>登录后才能查看你自己提交过的 DataPoints。</p>
+        <SignInButtons />
+      </div>
+    );
+  }
+
+  function startEdit(row) {
+    setEditing(row.d.id);
+    setDraft({
+      result: row.d.result || '',
+      is_funded: !!row.d.is_funded,
+      is_final_destination: !!row.d.is_final_destination,
+      academic_year: row.d.academic_year ?? '',
+      semester: row.d.semester || '',
+      notified_at: row.d.notified_at || '',
+      submitted_at: row.d.submitted_at || '',
+      notes: row.d.notes || '',
+    });
+  }
+
+  async function saveEdit(id) {
+    try {
+      const payload = { ...draft };
+      if (payload.academic_year === '') payload.academic_year = null;
+      else payload.academic_year = Number(payload.academic_year);
+      for (const k of ['result', 'semester', 'notified_at', 'submitted_at', 'notes']) {
+        if (payload[k] === '') payload[k] = null;
+      }
+      await updateDp(id, payload);
+      setMsg({ type: 'ok', text: '已更新' });
+      setEditing(null);
+      setDraft(null);
+      reload();
+    } catch (e) {
+      setMsg({ type: 'err', text: `更新失败：${e.message}` });
+    }
+  }
+
+  async function remove(id) {
+    if (!confirm('确认删除这条 DataPoint？此操作不可撤销。')) return;
+    try {
+      await deleteDp(id);
+      setMsg({ type: 'ok', text: '已删除' });
+      reload();
+    } catch (e) {
+      setMsg({ type: 'err', text: `删除失败：${e.message}` });
+    }
+  }
+
+  async function handleSignOut() {
+    await signOut();
+    window.location.href = '/datapoints-new';
+  }
+
+  return (
+    <div className={styles.wrap}>
+      <header className={styles.header}>
+        <div className={styles.headerTop}>
+          <h1>我的 DataPoints</h1>
+          <div className={styles.headerRight}>
+            <span className={styles.meBadge}>👤 {me.nickname}{me.role === 'admin' ? ' · admin' : ''}</span>
+            <button className={styles.linkBtn} onClick={handleSignOut}>登出</button>
+          </div>
+        </div>
+        {!applicant ? (
+          <p className={styles.notice}>
+            你还没有创建申请者背景档案。<a href="/submit-dp">去填写</a>后才能提交 DP。
+          </p>
+        ) : (
+          <p className={styles.lead}>
+            共 <b>{rows.length}</b> 条已提交。<a href="/submit-dp">提交新的 DP →</a>
+          </p>
+        )}
+        {msg ? <p className={msg.type === 'ok' ? styles.ok : styles.err}>{msg.text}</p> : null}
+      </header>
+
+      {loading ? <div className={styles.loading}>加载中…</div> : null}
+      {error ? <div className={styles.err}>{error}</div> : null}
+
+      {!loading && applicant && rows.length === 0 ? (
+        <div className={styles.empty}>
+          还没有 DP 记录。<a href="/submit-dp">现在提交第一条 →</a>
+        </div>
+      ) : null}
+
+      {rows.length > 0 ? (
+        <div className={styles.tableWrap}>
+          <table className={styles.table}>
+            <thead>
+              <tr>
+                <th>学校 · 项目</th>
+                <th>Tier</th>
+                <th>结果</th>
+                <th>带奖</th>
+                <th>最终</th>
+                <th>年份 / 学期</th>
+                <th>通知</th>
+                <th>提交</th>
+                <th>备注</th>
+                <th>操作</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => {
+                const isEditing = editing === row.d.id;
+                return (
+                  <tr key={row.d.id}>
+                    <td>
+                      <b>{row.p.school}</b>
+                      <br />
+                      <span className={styles.muted}>{row.p.program}</span>
+                    </td>
+                    <td>{row.p.tier || <span className={styles.muted}>—</span>}</td>
+                    <td>
+                      {isEditing ? (
+                        <select
+                          value={draft.result}
+                          onChange={(e) => setDraft({ ...draft, result: e.target.value })}
+                          className={styles.cellInput}
+                        >
+                          <option value="">—</option>
+                          {RESULTS.map((r) => <option key={r} value={r}>{r}</option>)}
+                        </select>
+                      ) : (
+                        <span className={`${styles.pill} ${pillClass(row.d.result)}`}>{row.d.result || '—'}</span>
+                      )}
+                    </td>
+                    <td>
+                      {isEditing ? (
+                        <input type="checkbox" checked={draft.is_funded} onChange={(e) => setDraft({ ...draft, is_funded: e.target.checked })} />
+                      ) : row.d.is_funded ? '✓' : ''}
+                    </td>
+                    <td>
+                      {isEditing ? (
+                        <input type="checkbox" checked={draft.is_final_destination} onChange={(e) => setDraft({ ...draft, is_final_destination: e.target.checked })} />
+                      ) : row.d.is_final_destination ? '✓' : ''}
+                    </td>
+                    <td>
+                      {isEditing ? (
+                        <>
+                          <input type="number" value={draft.academic_year} onChange={(e) => setDraft({ ...draft, academic_year: e.target.value })} className={styles.cellInput} style={{ width: 70 }} />
+                          <select value={draft.semester} onChange={(e) => setDraft({ ...draft, semester: e.target.value })} className={styles.cellInput}>
+                            <option value="">—</option>
+                            {SEMESTERS.map((s) => <option key={s} value={s}>{s}</option>)}
+                          </select>
+                        </>
+                      ) : (
+                        <>{row.d.academic_year} {row.d.semester}</>
+                      )}
+                    </td>
+                    <td>
+                      {isEditing ? (
+                        <input type="date" value={draft.notified_at} onChange={(e) => setDraft({ ...draft, notified_at: e.target.value })} className={styles.cellInput} />
+                      ) : (row.d.notified_at || <span className={styles.muted}>—</span>)}
+                    </td>
+                    <td>
+                      {isEditing ? (
+                        <input type="date" value={draft.submitted_at} onChange={(e) => setDraft({ ...draft, submitted_at: e.target.value })} className={styles.cellInput} />
+                      ) : (row.d.submitted_at || <span className={styles.muted}>—</span>)}
+                    </td>
+                    <td className={styles.notesCell}>
+                      {isEditing ? (
+                        <textarea value={draft.notes} onChange={(e) => setDraft({ ...draft, notes: e.target.value })} className={styles.cellInput} rows={2} />
+                      ) : (row.d.notes || <span className={styles.muted}>—</span>)}
+                    </td>
+                    <td className={styles.actionsCell}>
+                      {isEditing ? (
+                        <>
+                          <button className={styles.smallBtn} onClick={() => saveEdit(row.d.id)}>保存</button>
+                          <button className={styles.smallBtn} onClick={() => { setEditing(null); setDraft(null); }}>取消</button>
+                        </>
+                      ) : (
+                        <>
+                          <button className={styles.smallBtn} onClick={() => startEdit(row)}>编辑</button>
+                          <button className={`${styles.smallBtn} ${styles.dangerBtn}`} onClick={() => remove(row.d.id)}>删除</button>
+                        </>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function SignInButtons() {
+  async function signIn(provider) {
+    const r = await fetch(`${DP_API_BASE}/api/auth/sign-in/social`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ provider, callbackURL: window.location.href }),
+    });
+    const data = await r.json();
+    if (data.url) window.location.href = data.url;
+    else alert(`登录失败：${data.message || 'unknown'}`);
+  }
+  return (
+    <div className={styles.signInGroup}>
+      <button className={styles.signInBtn} onClick={() => signIn('google')}>Google 登录</button>
+      <button className={styles.signInBtn} onClick={() => signIn('github')}>GitHub 登录</button>
+    </div>
+  );
+}
+
+function pillClass(result) {
+  switch (result) {
+    case 'Admit': return styles.pillAdmit;
+    case 'Reject': case '默拒': return styles.pillReject;
+    case 'Waitlist': return styles.pillWait;
+    case 'Withdraw': return styles.pillWithdraw;
+    default: return styles.pillUnknown;
+  }
+}
+
+export default function MyDp() {
+  return (
+    <Layout title="我的 DataPoints" description="manage your csgrad DataPoints">
+      <BrowserOnly>{() => <Inner />}</BrowserOnly>
+    </Layout>
+  );
+}

--- a/src/pages/my-dp.module.css
+++ b/src/pages/my-dp.module.css
@@ -1,0 +1,141 @@
+.wrap { max-width: 1300px; margin: 0 auto; padding: 24px 20px 80px; }
+
+.loading, .empty {
+  padding: 40px;
+  text-align: center;
+  color: var(--ifm-color-emphasis-600);
+}
+
+.gate {
+  max-width: 480px;
+  margin: 60px auto;
+  padding: 32px;
+  text-align: center;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 12px;
+}
+
+.signInGroup { display: flex; gap: 8px; justify-content: center; margin-top: 16px; }
+.signInBtn {
+  padding: 8px 16px;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  background: var(--ifm-background-color);
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 14px;
+  color: var(--ifm-font-color-base);
+}
+.signInBtn:hover { background: var(--ifm-color-emphasis-100); }
+
+.header h1 { margin: 0 0 8px; font-size: 26px; }
+.headerTop {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.headerRight { display: flex; align-items: center; gap: 8px; }
+.lead { color: var(--ifm-color-emphasis-700); font-size: 14px; margin: 0 0 12px; }
+.notice {
+  padding: 10px 14px;
+  background: #fef3c7;
+  color: #92400e;
+  border-radius: 6px;
+  font-size: 13px;
+}
+.meBadge {
+  padding: 4px 10px;
+  background: var(--ifm-color-emphasis-100);
+  border-radius: 999px;
+  font-size: 13px;
+  color: var(--ifm-color-emphasis-800);
+}
+.linkBtn {
+  background: transparent;
+  border: 0;
+  color: var(--ifm-color-emphasis-700);
+  font-size: 13px;
+  cursor: pointer;
+  text-decoration: underline;
+}
+.linkBtn:hover { color: var(--ifm-color-primary); }
+
+.ok, .err {
+  padding: 8px 12px;
+  border-radius: 6px;
+  font-size: 13px;
+  margin: 8px 0;
+}
+.ok { background: #10b98120; color: #047857; }
+.err { background: #ef444420; color: #b91c1c; }
+
+.tableWrap {
+  overflow-x: auto;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 8px;
+}
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+.table th {
+  text-align: left;
+  padding: 8px 10px;
+  font-weight: 600;
+  font-size: 12px;
+  background: var(--ifm-color-emphasis-100);
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+  white-space: nowrap;
+}
+.table td {
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--ifm-color-emphasis-100);
+  vertical-align: top;
+}
+.table tbody tr:hover { background: var(--ifm-color-emphasis-100); }
+
+.muted { color: var(--ifm-color-emphasis-500); }
+
+.pill {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+}
+.pillAdmit { background: #10b98120; color: #047857; }
+.pillReject { background: #ef444420; color: #b91c1c; }
+.pillWait { background: #f59e0b20; color: #b45309; }
+.pillWithdraw { background: #6b728020; color: #4b5563; }
+.pillUnknown { background: var(--ifm-color-emphasis-200); color: var(--ifm-color-emphasis-700); }
+
+.notesCell { max-width: 260px; }
+
+.actionsCell { white-space: nowrap; }
+.smallBtn {
+  padding: 3px 8px;
+  margin-right: 4px;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  background: var(--ifm-background-color);
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 12px;
+  color: var(--ifm-font-color-base);
+}
+.smallBtn:hover { background: var(--ifm-color-emphasis-100); }
+.dangerBtn { color: #b91c1c; }
+.dangerBtn:hover { background: #fee2e2; }
+
+.cellInput {
+  padding: 3px 6px;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 4px;
+  font-size: 12px;
+  background: var(--ifm-background-color);
+  color: var(--ifm-font-color-base);
+  font-family: inherit;
+  margin-right: 2px;
+}
+textarea.cellInput { width: 100%; resize: vertical; min-height: 40px; }

--- a/src/pages/submit-dp.jsx
+++ b/src/pages/submit-dp.jsx
@@ -1,0 +1,533 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import Layout from '@theme/Layout';
+import BrowserOnly from '@docusaurus/BrowserOnly';
+import {
+  DP_API_BASE,
+  getMe,
+  getMyApplicant,
+  createMyApplicant,
+  updateMyApplicant,
+  createDp,
+  listPrograms,
+} from '@site/src/lib/dp/api';
+import {
+  UG_CATEGORIES, UG_MAJORS, CS_COURSES,
+  GPA_SCALES, GPA_RANKS, REC_TAGS, REC_TAGS_WITH_NONE,
+  RESULTS, SEMESTERS,
+} from '@site/src/lib/dp/enums';
+import styles from './submit-dp.module.css';
+
+const EMPTY_APPLICANT = {
+  ug_school_category: '', ug_school_name: '', graduation_year: '', ug_major: '',
+  honors_college: false, exchange_abroad: false, dual_degree: false,
+  education_notes: '', cs_courses: [],
+  gpa_scale: '', gpa: '', gpa_rank: '', gpa_notes: '',
+  toefl_total: '', toefl_reading: '', toefl_listening: '', toefl_speaking: '', toefl_writing: '',
+  ielts_total: '', ielts_reading: '', ielts_listening: '', ielts_speaking: '', ielts_writing: '',
+  gre_total: '', gre_quant: '', gre_verbal: '', gre_writing: '',
+  research_domestic_count: '', research_overseas_count: '', research_notes: '',
+  internship_domestic_count: '', internship_overseas_count: '', internship_notes: '',
+  rec1_tags: [], rec2_tags: [], rec3_tags: [], rec4_tags: [], rec5_tags: [], rec_notes: '',
+  pub_top_first_author: false, pub_top_other_author: false,
+  submission_top_first_author: false, submission_top_other_author: false,
+  pub_notes: '',
+  other_soft_background: '', contact_info: '',
+};
+
+function applicantToForm(a) {
+  if (!a) return EMPTY_APPLICANT;
+  const out = { ...EMPTY_APPLICANT };
+  for (const k of Object.keys(EMPTY_APPLICANT)) {
+    if (a[k] == null) continue;
+    if (Array.isArray(EMPTY_APPLICANT[k])) {
+      try { out[k] = typeof a[k] === 'string' ? JSON.parse(a[k]) : a[k]; }
+      catch { out[k] = []; }
+    } else if (typeof EMPTY_APPLICANT[k] === 'boolean') {
+      out[k] = Boolean(a[k]);
+    } else {
+      out[k] = a[k] ?? '';
+    }
+  }
+  return out;
+}
+
+function formToPayload(f) {
+  const payload = { ...f };
+  // serialize arrays to JSON strings (backend stores TEXT)
+  for (const k of ['cs_courses', 'rec1_tags', 'rec2_tags', 'rec3_tags', 'rec4_tags', 'rec5_tags']) {
+    payload[k] = JSON.stringify(f[k] || []);
+  }
+  // empty strings → null
+  for (const k of Object.keys(payload)) {
+    if (payload[k] === '') payload[k] = null;
+  }
+  return payload;
+}
+
+function Inner() {
+  const [me, setMe] = useState(null);
+  const [meChecked, setMeChecked] = useState(false);
+  const [applicant, setApplicant] = useState(null);
+  const [form, setForm] = useState(EMPTY_APPLICANT);
+  const [savingApplicant, setSavingApplicant] = useState(false);
+  const [msg, setMsg] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const meRes = await getMe();
+      if (cancelled) return;
+      setMe(meRes.user);
+      setMeChecked(true);
+      if (meRes.user) {
+        try {
+          const r = await getMyApplicant();
+          if (cancelled) return;
+          setApplicant(r.applicant);
+          if (r.applicant) setForm(applicantToForm(r.applicant));
+        } catch (e) {
+          // not signed in → 401 — already handled above
+        }
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  if (!meChecked) return <div className={styles.loading}>加载中…</div>;
+  if (!me) return <SignInGate />;
+
+  const locked = Boolean(applicant?.lockedAt && me.role !== 'admin');
+
+  function setField(k, v) {
+    setForm((prev) => ({ ...prev, [k]: v }));
+  }
+
+  function toggleArrayValue(k, value) {
+    setForm((prev) => {
+      const arr = prev[k] || [];
+      const next = arr.includes(value) ? arr.filter((x) => x !== value) : [...arr, value];
+      return { ...prev, [k]: next };
+    });
+  }
+
+  async function saveApplicant() {
+    setSavingApplicant(true);
+    setMsg(null);
+    try {
+      const payload = formToPayload(form);
+      if (applicant) {
+        await updateMyApplicant(payload);
+        setMsg({ type: 'ok', text: '已保存（如已锁定需要 admin 解锁才能再改）' });
+      } else {
+        const r = await createMyApplicant(payload);
+        setApplicant(r.row);
+        setMsg({ type: 'ok', text: '档案已创建并锁定。下面可以提交 DP 了。' });
+      }
+    } catch (e) {
+      setMsg({ type: 'err', text: `保存失败：${e.message}` });
+    } finally {
+      setSavingApplicant(false);
+    }
+  }
+
+  return (
+    <div className={styles.wrap}>
+      <header className={styles.header}>
+        <div className={styles.headerTop}>
+          <h1>提交 DataPoints</h1>
+          <span className={styles.meBadge}>👤 {me.nickname}{me.role === 'admin' ? ' · admin' : ''}</span>
+        </div>
+        <p className={styles.lead}>
+          先填一次<strong>申请者背景档案</strong>，再提交每个项目的录取数据点。
+          档案一经保存即锁定（防止历史 DP 背景信息漂移），如需修改请联系 admin。
+        </p>
+        {msg ? <p className={msg.type === 'ok' ? styles.ok : styles.err}>{msg.text}</p> : null}
+      </header>
+
+      <ApplicantForm
+        form={form}
+        setField={setField}
+        toggleArrayValue={toggleArrayValue}
+        locked={locked}
+        onSave={saveApplicant}
+        saving={savingApplicant}
+        hasExisting={Boolean(applicant)}
+      />
+
+      {applicant ? (
+        <DpAddArea applicantId={applicant.id} />
+      ) : (
+        <section className={styles.section}>
+          <h2>步骤 2 · 提交 DataPoints</h2>
+          <p className={styles.muted}>请先保存上方的背景档案。</p>
+        </section>
+      )}
+    </div>
+  );
+}
+
+function SignInGate() {
+  async function signIn(provider) {
+    const r = await fetch(`${DP_API_BASE}/api/auth/sign-in/social`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ provider, callbackURL: window.location.href }),
+    });
+    const data = await r.json();
+    if (data.url) window.location.href = data.url;
+    else alert(`登录失败：${data.message || 'unknown'}`);
+  }
+  return (
+    <div className={styles.gate}>
+      <h2>需要登录</h2>
+      <p>用 Google 或 GitHub 登录后才能提交 DataPoints。</p>
+      <div className={styles.signInGroup}>
+        <button className={styles.signInBtn} onClick={() => signIn('google')}>Google 登录</button>
+        <button className={styles.signInBtn} onClick={() => signIn('github')}>GitHub 登录</button>
+      </div>
+    </div>
+  );
+}
+
+// ---------- applicant form ----------
+
+function ApplicantForm({ form, setField, toggleArrayValue, locked, onSave, saving, hasExisting }) {
+  return (
+    <section className={styles.section}>
+      <h2>步骤 1 · 申请者背景档案 {locked ? <span className={styles.lockBadge}>🔒 已锁定</span> : null}</h2>
+
+      <fieldset disabled={locked} className={styles.fieldset}>
+        <Group title="教育背景">
+          <Select label="本科学校类别" value={form.ug_school_category} onChange={(v) => setField('ug_school_category', v)} options={UG_CATEGORIES} />
+          <Text label="本科学校名称" value={form.ug_school_name} onChange={(v) => setField('ug_school_name', v)} />
+          <Number label="毕业年份" value={form.graduation_year} onChange={(v) => setField('graduation_year', v)} />
+          <Select label="本科专业" value={form.ug_major} onChange={(v) => setField('ug_major', v)} options={UG_MAJORS} />
+          <Check label="荣誉学院" value={form.honors_college} onChange={(v) => setField('honors_college', v)} />
+          <Check label="海外交换" value={form.exchange_abroad} onChange={(v) => setField('exchange_abroad', v)} />
+          <Check label="陆本海本双学位" value={form.dual_degree} onChange={(v) => setField('dual_degree', v)} />
+          <LongText label="教育背景备注" value={form.education_notes} onChange={(v) => setField('education_notes', v)} />
+        </Group>
+
+        <Group title="核心课程修读">
+          <MultiCheck options={CS_COURSES} value={form.cs_courses} onToggle={(o) => toggleArrayValue('cs_courses', o)} />
+        </Group>
+
+        <Group title="GPA">
+          <Select label="本科分数制" value={form.gpa_scale} onChange={(v) => setField('gpa_scale', v)} options={GPA_SCALES} />
+          <Number label="本科 GPA" value={form.gpa} onChange={(v) => setField('gpa', v)} step="0.01" />
+          <Select label="本科 GPA 排名" value={form.gpa_rank} onChange={(v) => setField('gpa_rank', v)} options={GPA_RANKS} />
+          <LongText label="GPA 备注" value={form.gpa_notes} onChange={(v) => setField('gpa_notes', v)} />
+        </Group>
+
+        <Group title="TOEFL">
+          <Number label="总分" value={form.toefl_total} onChange={(v) => setField('toefl_total', v)} />
+          <Number label="阅读" value={form.toefl_reading} onChange={(v) => setField('toefl_reading', v)} />
+          <Number label="听力" value={form.toefl_listening} onChange={(v) => setField('toefl_listening', v)} />
+          <Number label="口语" value={form.toefl_speaking} onChange={(v) => setField('toefl_speaking', v)} />
+          <Number label="写作" value={form.toefl_writing} onChange={(v) => setField('toefl_writing', v)} />
+        </Group>
+
+        <Group title="IELTS">
+          <Number label="总分" value={form.ielts_total} onChange={(v) => setField('ielts_total', v)} step="0.5" />
+          <Number label="阅读" value={form.ielts_reading} onChange={(v) => setField('ielts_reading', v)} step="0.5" />
+          <Number label="听力" value={form.ielts_listening} onChange={(v) => setField('ielts_listening', v)} step="0.5" />
+          <Number label="口语" value={form.ielts_speaking} onChange={(v) => setField('ielts_speaking', v)} step="0.5" />
+          <Number label="写作" value={form.ielts_writing} onChange={(v) => setField('ielts_writing', v)} step="0.5" />
+        </Group>
+
+        <Group title="GRE">
+          <Number label="总分" value={form.gre_total} onChange={(v) => setField('gre_total', v)} />
+          <Number label="数学" value={form.gre_quant} onChange={(v) => setField('gre_quant', v)} />
+          <Number label="语文" value={form.gre_verbal} onChange={(v) => setField('gre_verbal', v)} />
+          <Number label="写作" value={form.gre_writing} onChange={(v) => setField('gre_writing', v)} step="0.5" />
+        </Group>
+
+        <Group title="科研经历">
+          <Number label="国内段数" value={form.research_domestic_count} onChange={(v) => setField('research_domestic_count', v)} />
+          <Number label="海外段数" value={form.research_overseas_count} onChange={(v) => setField('research_overseas_count', v)} />
+          <LongText label="科研经历介绍" value={form.research_notes} onChange={(v) => setField('research_notes', v)} />
+        </Group>
+
+        <Group title="实习经历">
+          <Number label="国内段数" value={form.internship_domestic_count} onChange={(v) => setField('internship_domestic_count', v)} />
+          <Number label="海外段数" value={form.internship_overseas_count} onChange={(v) => setField('internship_overseas_count', v)} />
+          <LongText label="实习经历介绍" value={form.internship_notes} onChange={(v) => setField('internship_notes', v)} />
+        </Group>
+
+        <Group title="推荐信（每封信可勾多个标签）">
+          {[1, 2, 3, 4, 5].map((n) => (
+            <RecLetterRow
+              key={n}
+              num={n}
+              value={form[`rec${n}_tags`]}
+              onToggle={(o) => toggleArrayValue(`rec${n}_tags`, o)}
+            />
+          ))}
+          <LongText label="推荐信介绍" value={form.rec_notes} onChange={(v) => setField('rec_notes', v)} />
+        </Group>
+
+        <Group title="科研产出">
+          <Check label="已发表顶会一作" value={form.pub_top_first_author} onChange={(v) => setField('pub_top_first_author', v)} />
+          <Check label="已发表顶会其他作者" value={form.pub_top_other_author} onChange={(v) => setField('pub_top_other_author', v)} />
+          <Check label="在投顶会一作" value={form.submission_top_first_author} onChange={(v) => setField('submission_top_first_author', v)} />
+          <Check label="在投顶会其他作者" value={form.submission_top_other_author} onChange={(v) => setField('submission_top_other_author', v)} />
+          <LongText label="Pub 情况" value={form.pub_notes} onChange={(v) => setField('pub_notes', v)} />
+        </Group>
+
+        <Group title="其他">
+          <LongText label="其他软背景" value={form.other_soft_background} onChange={(v) => setField('other_soft_background', v)} />
+          <LongText label="个人主页 / 联系方式（仅 admin 可见）" value={form.contact_info} onChange={(v) => setField('contact_info', v)} />
+        </Group>
+      </fieldset>
+
+      <div className={styles.actions}>
+        <button className={styles.primaryBtn} disabled={locked || saving} onClick={onSave}>
+          {saving ? '保存中…' : hasExisting ? '更新档案' : '创建档案（一次性，提交即锁定）'}
+        </button>
+      </div>
+    </section>
+  );
+}
+
+function RecLetterRow({ num, value, onToggle }) {
+  const opts = num >= 4 ? REC_TAGS_WITH_NONE : REC_TAGS;
+  return (
+    <div className={styles.recRow}>
+      <div className={styles.recLabel}>推荐信 {num}</div>
+      <div className={styles.tagWrap}>
+        {opts.map((o) => (
+          <button
+            key={o}
+            type="button"
+            className={`${styles.tag} ${(value || []).includes(o) ? styles.tagActive : ''}`}
+            onClick={() => onToggle(o)}
+            title={o}
+          >
+            {o.length > 20 ? o.slice(0, 18) + '…' : o}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ---------- DP add area ----------
+
+function DpAddArea({ applicantId }) {
+  const [programs, setPrograms] = useState([]);
+  const [progQuery, setProgQuery] = useState('');
+  const [selectedProgram, setSelectedProgram] = useState(null);
+  const [dp, setDp] = useState({
+    result: '', is_funded: false, is_final_destination: false,
+    academic_year: new Date().getFullYear(),
+    semester: 'Fall',
+    notified_at: '', submitted_at: '', notes: '',
+  });
+  const [saving, setSaving] = useState(false);
+  const [msg, setMsg] = useState(null);
+  const [recent, setRecent] = useState([]);
+
+  // initial programs load (small page; rely on search for full list)
+  useEffect(() => {
+    listPrograms({ limit: 500 }).then((r) => setPrograms(r.rows || [])).catch(() => {});
+  }, []);
+
+  const filteredPrograms = useMemo(() => {
+    const q = progQuery.trim().toLowerCase();
+    if (!q) return programs.slice(0, 20);
+    return programs
+      .filter((p) => `${p.school} ${p.program}`.toLowerCase().includes(q))
+      .slice(0, 20);
+  }, [programs, progQuery]);
+
+  async function submit() {
+    if (!selectedProgram) {
+      setMsg({ type: 'err', text: '请先选择项目' });
+      return;
+    }
+    if (!dp.result) {
+      setMsg({ type: 'err', text: '请选择结果' });
+      return;
+    }
+    setSaving(true);
+    setMsg(null);
+    try {
+      const r = await createDp({
+        program_id: selectedProgram.id,
+        result: dp.result,
+        is_funded: dp.is_funded,
+        is_final_destination: dp.is_final_destination,
+        academic_year: dp.academic_year ? Number(dp.academic_year) : null,
+        semester: dp.semester || null,
+        notified_at: dp.notified_at || null,
+        submitted_at: dp.submitted_at || null,
+        notes: dp.notes || null,
+      });
+      setRecent((prev) => [{ ...r.row, programSchool: selectedProgram.school, programName: selectedProgram.program }, ...prev]);
+      setMsg({ type: 'ok', text: `已提交：${selectedProgram.school} ${selectedProgram.program} → ${dp.result}` });
+      // reset for next entry, keep year/semester
+      setSelectedProgram(null);
+      setProgQuery('');
+      setDp((prev) => ({ ...prev, result: '', is_funded: false, is_final_destination: false, notified_at: '', submitted_at: '', notes: '' }));
+    } catch (e) {
+      setMsg({ type: 'err', text: `提交失败：${e.message}` });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <section className={styles.section}>
+      <h2>步骤 2 · 提交 DataPoints（可重复提交多条）</h2>
+      {msg ? <p className={msg.type === 'ok' ? styles.ok : styles.err}>{msg.text}</p> : null}
+
+      <div className={styles.dpForm}>
+        <div className={styles.programSearch}>
+          <label>项目（搜学校或 program 名）</label>
+          <input
+            className={styles.input}
+            placeholder="如 stanford mscs / CMU MIIS"
+            value={selectedProgram ? `${selectedProgram.school} · ${selectedProgram.program}` : progQuery}
+            onChange={(e) => { setSelectedProgram(null); setProgQuery(e.target.value); }}
+          />
+          {!selectedProgram && progQuery && filteredPrograms.length > 0 ? (
+            <ul className={styles.progDropdown}>
+              {filteredPrograms.map((p) => (
+                <li key={p.id} onClick={() => { setSelectedProgram(p); setProgQuery(''); }}>
+                  <b>{p.school}</b> · {p.program}
+                  {p.tier ? <span className={styles.tierBadge}>{p.tier}</span> : null}
+                  {p.degree ? <span className={styles.muted}> {p.degree}</span> : null}
+                </li>
+              ))}
+            </ul>
+          ) : null}
+        </div>
+
+        <div className={styles.row}>
+          <Select label="结果" value={dp.result} onChange={(v) => setDp({ ...dp, result: v })} options={RESULTS} />
+          <Number label="学年" value={dp.academic_year} onChange={(v) => setDp({ ...dp, academic_year: v })} />
+          <Select label="学期" value={dp.semester} onChange={(v) => setDp({ ...dp, semester: v })} options={SEMESTERS} />
+          <Check label="带奖" value={dp.is_funded} onChange={(v) => setDp({ ...dp, is_funded: v })} />
+          <Check label="最终去向" value={dp.is_final_destination} onChange={(v) => setDp({ ...dp, is_final_destination: v })} />
+        </div>
+        <div className={styles.row}>
+          <Date label="通知时间" value={dp.notified_at} onChange={(v) => setDp({ ...dp, notified_at: v })} />
+          <Date label="网申提交时间" value={dp.submitted_at} onChange={(v) => setDp({ ...dp, submitted_at: v })} />
+        </div>
+        <LongText label="补充说明 / 面试 / 联系等" value={dp.notes} onChange={(v) => setDp({ ...dp, notes: v })} />
+
+        <div className={styles.actions}>
+          <button className={styles.primaryBtn} disabled={saving} onClick={submit}>
+            {saving ? '提交中…' : '提交这条 DP'}
+          </button>
+          <a className={styles.secondaryLink} href="/my-dp">查看我提交过的 DP →</a>
+        </div>
+      </div>
+
+      {recent.length > 0 ? (
+        <div className={styles.recentList}>
+          <h3>本次会话刚提交的</h3>
+          <ul>
+            {recent.map((r) => (
+              <li key={r.id}>
+                <span className={styles.pillSmall}>{r.result}</span> {r.programSchool} · {r.programName}
+                {r.is_funded ? <span className={styles.badge}>奖</span> : null}
+                {r.is_final_destination ? <span className={styles.badge}>最终</span> : null}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+// ---------- form primitives ----------
+
+function Group({ title, children }) {
+  return (
+    <div className={styles.group}>
+      <h3 className={styles.groupTitle}>{title}</h3>
+      <div className={styles.groupBody}>{children}</div>
+    </div>
+  );
+}
+
+function Text({ label, value, onChange }) {
+  return (
+    <label className={styles.field}>
+      <span>{label}</span>
+      <input className={styles.input} value={value ?? ''} onChange={(e) => onChange(e.target.value)} />
+    </label>
+  );
+}
+
+function Number({ label, value, onChange, step }) {
+  return (
+    <label className={styles.field}>
+      <span>{label}</span>
+      <input type="number" step={step || '1'} className={styles.input} value={value ?? ''} onChange={(e) => onChange(e.target.value)} />
+    </label>
+  );
+}
+
+function Date({ label, value, onChange }) {
+  return (
+    <label className={styles.field}>
+      <span>{label}</span>
+      <input type="date" className={styles.input} value={value ?? ''} onChange={(e) => onChange(e.target.value)} />
+    </label>
+  );
+}
+
+function Select({ label, value, onChange, options }) {
+  return (
+    <label className={styles.field}>
+      <span>{label}</span>
+      <select className={styles.input} value={value ?? ''} onChange={(e) => onChange(e.target.value)}>
+        <option value="">（请选择）</option>
+        {options.map((o) => <option key={o} value={o}>{o}</option>)}
+      </select>
+    </label>
+  );
+}
+
+function Check({ label, value, onChange }) {
+  return (
+    <label className={styles.checkField}>
+      <input type="checkbox" checked={Boolean(value)} onChange={(e) => onChange(e.target.checked)} />
+      <span>{label}</span>
+    </label>
+  );
+}
+
+function LongText({ label, value, onChange }) {
+  return (
+    <label className={`${styles.field} ${styles.longTextField}`}>
+      <span>{label}</span>
+      <textarea className={styles.textarea} rows={3} value={value ?? ''} onChange={(e) => onChange(e.target.value)} />
+    </label>
+  );
+}
+
+function MultiCheck({ options, value, onToggle }) {
+  return (
+    <div className={styles.multiCheck}>
+      {options.map((o) => (
+        <label key={o} className={styles.multiCheckItem}>
+          <input type="checkbox" checked={(value || []).includes(o)} onChange={() => onToggle(o)} />
+          <span>{o}</span>
+        </label>
+      ))}
+    </div>
+  );
+}
+
+export default function SubmitDp() {
+  return (
+    <Layout title="提交 DataPoints" description="csgrad DataPoints submission form">
+      <BrowserOnly>{() => <Inner />}</BrowserOnly>
+    </Layout>
+  );
+}

--- a/src/pages/submit-dp.module.css
+++ b/src/pages/submit-dp.module.css
@@ -1,0 +1,293 @@
+.wrap {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 24px 20px 80px;
+}
+
+.loading {
+  padding: 60px;
+  text-align: center;
+  color: var(--ifm-color-emphasis-600);
+}
+
+.gate {
+  max-width: 480px;
+  margin: 60px auto;
+  padding: 32px;
+  text-align: center;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 12px;
+}
+
+.signInGroup {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  margin-top: 16px;
+}
+
+.signInBtn {
+  padding: 8px 16px;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  background: var(--ifm-background-color);
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 14px;
+  color: var(--ifm-font-color-base);
+}
+.signInBtn:hover { background: var(--ifm-color-emphasis-100); }
+
+.header h1 { margin: 0 0 8px; font-size: 26px; }
+.headerTop {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.lead { color: var(--ifm-color-emphasis-700); font-size: 14px; margin: 0 0 8px; line-height: 1.6; }
+.meBadge {
+  padding: 4px 10px;
+  background: var(--ifm-color-emphasis-100);
+  border-radius: 999px;
+  font-size: 13px;
+  color: var(--ifm-color-emphasis-800);
+}
+
+.section {
+  margin-top: 24px;
+  padding: 20px;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 12px;
+  background: var(--ifm-background-color);
+}
+.section h2 {
+  margin: 0 0 16px;
+  font-size: 18px;
+}
+.lockBadge {
+  margin-left: 8px;
+  padding: 2px 8px;
+  background: #fde68a;
+  color: #92400e;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  vertical-align: middle;
+}
+
+.ok, .err {
+  padding: 8px 12px;
+  border-radius: 6px;
+  font-size: 13px;
+  margin: 0 0 8px;
+}
+.ok { background: #10b98120; color: #047857; }
+.err { background: #ef444420; color: #b91c1c; }
+
+.fieldset { border: 0; padding: 0; margin: 0; }
+.fieldset[disabled] { opacity: 0.6; }
+
+.group {
+  margin-bottom: 20px;
+  padding: 14px;
+  background: var(--ifm-color-emphasis-100);
+  border-radius: 8px;
+}
+.groupTitle {
+  margin: 0 0 12px;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--ifm-color-emphasis-800);
+}
+.groupBody {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 10px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 11px;
+  color: var(--ifm-color-emphasis-700);
+}
+.field > span { font-size: 11px; }
+.longTextField { grid-column: 1 / -1; }
+
+.input, .textarea {
+  padding: 6px 10px;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 6px;
+  font-size: 13px;
+  background: var(--ifm-background-color);
+  color: var(--ifm-font-color-base);
+  font-family: inherit;
+}
+.textarea { min-height: 60px; resize: vertical; }
+
+.checkField {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  font-size: 13px;
+  padding: 6px;
+}
+.fieldset[disabled] .checkField { cursor: not-allowed; }
+
+.multiCheck {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 6px;
+}
+.multiCheckItem {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.recRow {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 8px;
+}
+.recLabel {
+  font-size: 12px;
+  font-weight: 600;
+  min-width: 60px;
+  color: var(--ifm-color-emphasis-800);
+}
+.tagWrap {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  flex: 1;
+}
+.tag {
+  padding: 3px 8px;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  background: var(--ifm-background-color);
+  border-radius: 999px;
+  cursor: pointer;
+  font-size: 11px;
+  color: var(--ifm-font-color-base);
+  white-space: nowrap;
+}
+.tag:hover { background: var(--ifm-color-emphasis-100); }
+.tagActive {
+  background: var(--ifm-color-primary);
+  color: var(--ifm-color-white);
+  border-color: var(--ifm-color-primary);
+}
+
+.actions {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  margin-top: 16px;
+}
+.primaryBtn {
+  padding: 8px 16px;
+  background: var(--ifm-color-primary);
+  color: var(--ifm-color-white);
+  border: 0;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 600;
+}
+.primaryBtn:disabled { opacity: 0.5; cursor: not-allowed; }
+.primaryBtn:hover:not(:disabled) { background: var(--ifm-color-primary-dark); }
+
+.secondaryLink {
+  color: var(--ifm-color-primary);
+  font-size: 13px;
+}
+
+/* DP add area */
+.dpForm { display: flex; flex-direction: column; gap: 12px; }
+
+.programSearch { position: relative; }
+.programSearch label {
+  display: block;
+  font-size: 11px;
+  color: var(--ifm-color-emphasis-700);
+  margin-bottom: 4px;
+}
+.progDropdown {
+  position: absolute;
+  z-index: 10;
+  list-style: none;
+  margin: 4px 0 0;
+  padding: 4px 0;
+  background: var(--ifm-background-color);
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 6px;
+  width: 100%;
+  max-height: 320px;
+  overflow-y: auto;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+}
+.progDropdown li {
+  padding: 6px 12px;
+  cursor: pointer;
+  font-size: 13px;
+}
+.progDropdown li:hover { background: var(--ifm-color-emphasis-100); }
+.tierBadge {
+  display: inline-block;
+  margin-left: 6px;
+  padding: 1px 6px;
+  background: #c7d2fe;
+  color: #3730a3;
+  border-radius: 4px;
+  font-size: 10px;
+  font-weight: 600;
+}
+.muted { color: var(--ifm-color-emphasis-500); font-size: 11px; }
+
+.row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 10px;
+}
+
+.recentList { margin-top: 20px; }
+.recentList h3 { font-size: 14px; margin: 0 0 8px; }
+.recentList ul { list-style: none; padding: 0; margin: 0; }
+.recentList li {
+  padding: 6px 10px;
+  background: var(--ifm-color-emphasis-100);
+  border-radius: 6px;
+  margin-bottom: 4px;
+  font-size: 13px;
+}
+
+.pillSmall {
+  display: inline-block;
+  padding: 1px 8px;
+  background: #10b98120;
+  color: #047857;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  margin-right: 6px;
+}
+.badge {
+  display: inline-block;
+  margin-left: 4px;
+  padding: 1px 5px;
+  background: #fde68a;
+  color: #92400e;
+  border-radius: 3px;
+  font-size: 10px;
+  font-weight: 600;
+}


### PR DESCRIPTION
## Summary
闭环 DP 提交流程，替代 Google Forms：
- `/submit-dp` — 两步提交（申请者背景档案 + DP 提交区），程序搜索 combobox
- `/my-dp` — 我的 DP 列表，行内编辑 + 删除

后端 API 都已在 PR #1 中合入，本 PR 只是前端 wire 起来。

## Test plan
- [x] `npm run build` 通过；`/submit-dp` 和 `/my-dp` index.html 已生成
- [ ] 上线后试登录 → 填档案 → 提交 1 条 DP → 在 /my-dp 看到 → 编辑 → 删除