### PR TITLE
feat(datapoints): CSS 暗色模式 + 颜色 token 中心化

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -4,6 +4,10 @@
  * work well for content-centric websites.
  */
 
+/* DataPoints semantic color tokens (light + dark). Centralizes pill/badge
+   colors so dark mode flips at one source of truth. */
+@import '../styles/dp-tokens.css';
+
 /* You can override the default Infima variables here. */
 :root {
   --ifm-color-primary: #2e8555;

--- a/src/pages/datapoints.module.css
+++ b/src/pages/datapoints.module.css
@@ -21,8 +21,8 @@
   margin: 0 0 16px;
 }
 .beta {
-  background: #f0a82220;
-  color: #c47a00;
+  background: var(--dp-beta-bg);
+  color: var(--dp-beta-fg);
   padding: 1px 6px;
   border-radius: 4px;
   font-weight: 600;
@@ -223,8 +223,8 @@
   font-weight: 600;
   white-space: nowrap;
 }
-.countDomestic { background: #fef3c7; color: #92400e; }
-.countOverseas { background: #dbeafe; color: #1e40af; }
+.countDomestic { background: var(--dp-count-domestic-bg); color: var(--dp-count-domestic-fg); }
+.countOverseas { background: var(--dp-count-overseas-bg); color: var(--dp-count-overseas-fg); }
 
 .pubCell { white-space: nowrap; }
 .pubBadges { display: inline-flex; gap: 3px; }
@@ -237,10 +237,10 @@
   letter-spacing: 0.5px;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
 }
-.pubFilled       { background: #6366f1; color: #fff; }
-.pubFilledAlt    { background: #818cf8; color: #fff; }
-.pubOutlined     { background: transparent; color: #6366f1; border: 1px solid #6366f1; padding: 1px 5px; }
-.pubOutlinedAlt  { background: transparent; color: #818cf8; border: 1px solid #c7d2fe; padding: 1px 5px; }
+.pubFilled       { background: var(--dp-pub-filled-bg); color: var(--dp-pub-filled-fg); }
+.pubFilledAlt    { background: var(--dp-pub-filled-alt-bg); color: var(--dp-pub-filled-alt-fg); }
+.pubOutlined     { background: transparent; color: var(--dp-pub-outlined-fg); border: 1px solid var(--dp-pub-outlined-border); padding: 1px 5px; }
+.pubOutlinedAlt  { background: transparent; color: var(--dp-pub-outlined-alt-fg); border: 1px solid var(--dp-pub-outlined-alt-border); padding: 1px 5px; }
 
 .notesCell { max-width: 280px; min-width: 180px; }
 .notesPreview {
@@ -270,10 +270,10 @@
   font-weight: 700;
   letter-spacing: 0.3px;
 }
-.pillAdmit    { background: #d1fae5; color: #065f46; }
-.pillReject   { background: #fee2e2; color: #b91c1c; }
-.pillWait     { background: #fef3c7; color: #b45309; }
-.pillWithdraw { background: #e5e7eb; color: #4b5563; }
+.pillAdmit    { background: var(--dp-pill-admit-bg); color: var(--dp-pill-admit-fg); }
+.pillReject   { background: var(--dp-pill-reject-bg); color: var(--dp-pill-reject-fg); }
+.pillWait     { background: var(--dp-pill-wait-bg); color: var(--dp-pill-wait-fg); }
+.pillWithdraw { background: var(--dp-pill-withdraw-bg); color: var(--dp-pill-withdraw-fg); }
 .pillUnknown  { background: var(--ifm-color-emphasis-200); color: var(--ifm-color-emphasis-700); }
 
 .fundBadge {
@@ -281,8 +281,8 @@
   margin-left: 5px;
   padding: 2px 6px;
   font-size: 10px;
-  background: #fde68a;
-  color: #92400e;
+  background: var(--dp-fund-bg);
+  color: var(--dp-fund-fg);
   border-radius: 3px;
   font-weight: 700;
   letter-spacing: 0.5px;
@@ -292,8 +292,8 @@
   margin-left: 5px;
   padding: 2px 6px;
   font-size: 10px;
-  background: #c7d2fe;
-  color: #3730a3;
+  background: var(--dp-final-bg);
+  color: var(--dp-final-fg);
   border-radius: 3px;
   font-weight: 700;
   letter-spacing: 0.5px;
@@ -308,11 +308,11 @@
   border-radius: 3px;
   letter-spacing: 0.5px;
 }
-.tierSSS { background: #fce7f3; color: #9d174d; }
-.tierSS  { background: #fee2e2; color: #b91c1c; }
-.tierS   { background: #fed7aa; color: #9a3412; }
-.tierA   { background: #fef3c7; color: #92400e; }
-.tierB   { background: #d1fae5; color: #065f46; }
+.tierSSS { background: var(--dp-tier-sss-bg); color: var(--dp-tier-sss-fg); }
+.tierSS  { background: var(--dp-tier-ss-bg); color: var(--dp-tier-ss-fg); }
+.tierS   { background: var(--dp-tier-s-bg); color: var(--dp-tier-s-fg); }
+.tierA   { background: var(--dp-tier-a-bg); color: var(--dp-tier-a-fg); }
+.tierB   { background: var(--dp-tier-b-bg); color: var(--dp-tier-b-fg); }
 .tierDefault { background: var(--ifm-color-emphasis-200); color: var(--ifm-color-emphasis-700); }
 
 /* ---------- UG category color tags ---------- */
@@ -324,13 +324,13 @@
   border-radius: 4px;
   white-space: nowrap;
 }
-.ugRed     { background: #fee2e2; color: #991b1b; }
-.ugRedAlt  { background: #fef2f2; color: #b91c1c; }
-.ugBlue    { background: #dbeafe; color: #1e40af; }
-.ugCyan    { background: #cffafe; color: #155e75; }
+.ugRed     { background: var(--dp-ug-red-bg); color: var(--dp-ug-red-fg); }
+.ugRedAlt  { background: var(--dp-ug-redalt-bg); color: var(--dp-ug-redalt-fg); }
+.ugBlue    { background: var(--dp-ug-blue-bg); color: var(--dp-ug-blue-fg); }
+.ugCyan    { background: var(--dp-ug-cyan-bg); color: var(--dp-ug-cyan-fg); }
 .ugGray    { background: var(--ifm-color-emphasis-200); color: var(--ifm-color-emphasis-700); }
-.ugGreen   { background: #d1fae5; color: #065f46; }
-.ugPurple  { background: #ede9fe; color: #5b21b6; }
+.ugGreen   { background: var(--dp-ug-green-bg); color: var(--dp-ug-green-fg); }
+.ugPurple  { background: var(--dp-ug-purple-bg); color: var(--dp-ug-purple-fg); }
 
 /* ---------- misc ---------- */
 .muted {
@@ -373,7 +373,7 @@
   text-align: center;
   color: var(--ifm-color-emphasis-600);
 }
-.errorBox { color: #b91c1c; }
+.errorBox { color: var(--dp-banner-err-fg); }
 
 /* ---------- header (sign in / toggle) ---------- */
 .headerTop {
@@ -417,7 +417,7 @@
 }
 .liveToggle input { cursor: pointer; }
 .liveErr {
-  color: #b45309;
+  color: var(--dp-banner-warn-text);
   font-size: 12px;
   margin: 0 0 8px;
 }

--- a/src/pages/my-dp.module.css
+++ b/src/pages/my-dp.module.css
@@ -39,8 +39,8 @@
 .lead { color: var(--ifm-color-emphasis-700); font-size: 14px; margin: 0 0 12px; }
 .notice {
   padding: 10px 14px;
-  background: #fef3c7;
-  color: #92400e;
+  background: var(--dp-banner-warn-bg);
+  color: var(--dp-banner-warn-text);
   border-radius: 6px;
   font-size: 13px;
 }
@@ -67,8 +67,8 @@
   font-size: 13px;
   margin: 8px 0;
 }
-.ok { background: #10b98120; color: #047857; }
-.err { background: #ef444420; color: #b91c1c; }
+.ok { background: var(--dp-banner-ok-bg); color: var(--dp-banner-ok-fg); }
+.err { background: var(--dp-banner-err-bg); color: var(--dp-banner-err-fg); }
 
 .tableWrap {
   overflow-x: auto;
@@ -105,10 +105,10 @@
   font-size: 11px;
   font-weight: 600;
 }
-.pillAdmit { background: #10b98120; color: #047857; }
-.pillReject { background: #ef444420; color: #b91c1c; }
-.pillWait { background: #f59e0b20; color: #b45309; }
-.pillWithdraw { background: #6b728020; color: #4b5563; }
+.pillAdmit { background: var(--dp-pill-admit-soft-bg); color: var(--dp-pill-admit-soft-fg); }
+.pillReject { background: var(--dp-pill-reject-soft-bg); color: var(--dp-pill-reject-soft-fg); }
+.pillWait { background: var(--dp-pill-wait-soft-bg); color: var(--dp-pill-wait-soft-fg); }
+.pillWithdraw { background: var(--dp-pill-withdraw-soft-bg); color: var(--dp-pill-withdraw-soft-fg); }
 .pillUnknown { background: var(--ifm-color-emphasis-200); color: var(--ifm-color-emphasis-700); }
 
 .notesCell { max-width: 260px; }
@@ -125,8 +125,8 @@
   color: var(--ifm-font-color-base);
 }
 .smallBtn:hover { background: var(--ifm-color-emphasis-100); }
-.dangerBtn { color: #b91c1c; }
-.dangerBtn:hover { background: #fee2e2; }
+.dangerBtn { color: var(--dp-danger-fg); }
+.dangerBtn:hover { background: var(--dp-danger-hover-bg); }
 
 .cellInput {
   padding: 3px 6px;

--- a/src/pages/submit-dp.module.css
+++ b/src/pages/submit-dp.module.css
@@ -68,8 +68,8 @@
 .lockBadge {
   margin-left: 8px;
   padding: 2px 8px;
-  background: #fde68a;
-  color: #92400e;
+  background: var(--dp-fund-bg);
+  color: var(--dp-fund-fg);
   border-radius: 999px;
   font-size: 11px;
   font-weight: 600;
@@ -82,8 +82,8 @@
   font-size: 13px;
   margin: 0 0 8px;
 }
-.ok { background: #10b98120; color: #047857; }
-.err { background: #ef444420; color: #b91c1c; }
+.ok { background: var(--dp-banner-ok-bg); color: var(--dp-banner-ok-fg); }
+.err { background: var(--dp-banner-err-bg); color: var(--dp-banner-err-fg); }
 
 .fieldset { border: 0; padding: 0; margin: 0; }
 .fieldset[disabled] { opacity: 0.6; }
@@ -246,8 +246,8 @@
   display: inline-block;
   margin-left: 6px;
   padding: 1px 6px;
-  background: #c7d2fe;
-  color: #3730a3;
+  background: var(--dp-final-bg);
+  color: var(--dp-final-fg);
   border-radius: 4px;
   font-size: 10px;
   font-weight: 600;
@@ -274,8 +274,8 @@
 .pillSmall {
   display: inline-block;
   padding: 1px 8px;
-  background: #10b98120;
-  color: #047857;
+  background: var(--dp-pill-admit-soft-bg);
+  color: var(--dp-pill-admit-soft-fg);
   border-radius: 999px;
   font-size: 11px;
   font-weight: 600;
@@ -285,8 +285,8 @@
   display: inline-block;
   margin-left: 4px;
   padding: 1px 5px;
-  background: #fde68a;
-  color: #92400e;
+  background: var(--dp-fund-bg);
+  color: var(--dp-fund-fg);
   border-radius: 3px;
   font-size: 10px;
   font-weight: 600;

--- a/src/styles/dp-tokens.css
+++ b/src/styles/dp-tokens.css
@@ -1,0 +1,181 @@
+/**
+ * DataPoints color tokens.
+ *
+ * Centralizes pill/badge colors for /datapoints, /submit-dp, /my-dp so that
+ * dark mode flips at a single source of truth instead of being scattered as
+ * raw hex across each .module.css file.
+ *
+ * Light-mode pairs are picked to meet WCAG AA contrast (>= 4.5:1) on the
+ * 10-12px text used by the pills/badges. Dark-mode pairs use translucent
+ * accent backgrounds over the page bg so they remain legible on the dark
+ * surface without re-introducing harsh light blobs.
+ *
+ * Loaded globally via `@import` from src/css/custom.css (which Docusaurus
+ * already registers as customCss in docusaurus.config.js).
+ */
+
+:root {
+  /* Result pills */
+  --dp-pill-admit-bg: #d1fae5;
+  --dp-pill-admit-fg: #065f46;
+  --dp-pill-reject-bg: #fee2e2;
+  --dp-pill-reject-fg: #991b1b;
+  --dp-pill-wait-bg: #fef3c7;
+  --dp-pill-wait-fg: #854d0e;
+  --dp-pill-withdraw-bg: #e5e7eb;
+  --dp-pill-withdraw-fg: #374151;
+
+  /* Translucent variants used by submit-dp / my-dp banners + tiny pills */
+  --dp-pill-admit-soft-bg: #d1fae5;
+  --dp-pill-admit-soft-fg: #047857;
+  --dp-pill-reject-soft-bg: #fee2e2;
+  --dp-pill-reject-soft-fg: #b91c1c;
+  --dp-pill-wait-soft-bg: #fef3c7;
+  --dp-pill-wait-soft-fg: #b45309;
+  --dp-pill-withdraw-soft-bg: #e5e7eb;
+  --dp-pill-withdraw-soft-fg: #4b5563;
+
+  /* Count badges (domestic = amber, overseas = blue) */
+  --dp-count-domestic-bg: #fef3c7;
+  --dp-count-domestic-fg: #78350f;
+  --dp-count-overseas-bg: #dbeafe;
+  --dp-count-overseas-fg: #1e3a8a;
+
+  /* Funded / final-destination tags */
+  --dp-fund-bg: #fde68a;
+  --dp-fund-fg: #78350f;
+  --dp-final-bg: #c7d2fe;
+  --dp-final-fg: #3730a3;
+
+  /* School tier badges */
+  --dp-tier-sss-bg: #fce7f3;
+  --dp-tier-sss-fg: #9d174d;
+  --dp-tier-ss-bg: #fee2e2;
+  --dp-tier-ss-fg: #991b1b;
+  --dp-tier-s-bg: #fed7aa;
+  --dp-tier-s-fg: #7c2d12;
+  --dp-tier-a-bg: #fef3c7;
+  --dp-tier-a-fg: #78350f;
+  --dp-tier-b-bg: #d1fae5;
+  --dp-tier-b-fg: #065f46;
+
+  /* UG (undergrad) category color tags */
+  --dp-ug-red-bg: #fee2e2;
+  --dp-ug-red-fg: #7f1d1d;
+  --dp-ug-redalt-bg: #fef2f2;
+  --dp-ug-redalt-fg: #991b1b;
+  --dp-ug-blue-bg: #dbeafe;
+  --dp-ug-blue-fg: #1e3a8a;
+  --dp-ug-cyan-bg: #cffafe;
+  --dp-ug-cyan-fg: #155e75;
+  --dp-ug-green-bg: #d1fae5;
+  --dp-ug-green-fg: #065f46;
+  --dp-ug-purple-bg: #ede9fe;
+  --dp-ug-purple-fg: #5b21b6;
+
+  /* Publication badges (indigo accent) */
+  --dp-pub-filled-bg: #6366f1;
+  --dp-pub-filled-fg: #ffffff;
+  --dp-pub-filled-alt-bg: #818cf8;
+  --dp-pub-filled-alt-fg: #ffffff;
+  --dp-pub-outlined-fg: #4f46e5;
+  --dp-pub-outlined-border: #6366f1;
+  --dp-pub-outlined-alt-fg: #6366f1;
+  --dp-pub-outlined-alt-border: #c7d2fe;
+
+  /* Beta tag (orange) */
+  --dp-beta-bg: #ffedd5;
+  --dp-beta-fg: #9a3412;
+
+  /* Banners: success / error / warning (live-feed err, my-dp notice) */
+  --dp-banner-ok-bg: #d1fae5;
+  --dp-banner-ok-fg: #065f46;
+  --dp-banner-err-bg: #fee2e2;
+  --dp-banner-err-fg: #991b1b;
+  --dp-banner-warn-bg: #fef3c7;
+  --dp-banner-warn-fg: #854d0e;
+  --dp-banner-warn-text: #92400e;
+
+  /* Danger button hover (my-dp) */
+  --dp-danger-fg: #b91c1c;
+  --dp-danger-hover-bg: #fee2e2;
+}
+
+/* Dark-mode overrides: translucent accents over the dark page bg keep
+   contrast >= 4.5:1 on small text while avoiding bright light blobs. */
+[data-theme='dark'] {
+  --dp-pill-admit-bg: rgba(16, 185, 129, 0.22);
+  --dp-pill-admit-fg: #6ee7b7;
+  --dp-pill-reject-bg: rgba(239, 68, 68, 0.22);
+  --dp-pill-reject-fg: #fca5a5;
+  --dp-pill-wait-bg: rgba(245, 158, 11, 0.22);
+  --dp-pill-wait-fg: #fcd34d;
+  --dp-pill-withdraw-bg: rgba(148, 163, 184, 0.22);
+  --dp-pill-withdraw-fg: #cbd5e1;
+
+  --dp-pill-admit-soft-bg: rgba(16, 185, 129, 0.18);
+  --dp-pill-admit-soft-fg: #6ee7b7;
+  --dp-pill-reject-soft-bg: rgba(239, 68, 68, 0.18);
+  --dp-pill-reject-soft-fg: #fca5a5;
+  --dp-pill-wait-soft-bg: rgba(245, 158, 11, 0.18);
+  --dp-pill-wait-soft-fg: #fcd34d;
+  --dp-pill-withdraw-soft-bg: rgba(148, 163, 184, 0.18);
+  --dp-pill-withdraw-soft-fg: #cbd5e1;
+
+  --dp-count-domestic-bg: rgba(245, 158, 11, 0.20);
+  --dp-count-domestic-fg: #fcd34d;
+  --dp-count-overseas-bg: rgba(59, 130, 246, 0.22);
+  --dp-count-overseas-fg: #93c5fd;
+
+  --dp-fund-bg: rgba(245, 158, 11, 0.22);
+  --dp-fund-fg: #fcd34d;
+  --dp-final-bg: rgba(99, 102, 241, 0.25);
+  --dp-final-fg: #c7d2fe;
+
+  --dp-tier-sss-bg: rgba(236, 72, 153, 0.22);
+  --dp-tier-sss-fg: #f9a8d4;
+  --dp-tier-ss-bg: rgba(239, 68, 68, 0.22);
+  --dp-tier-ss-fg: #fca5a5;
+  --dp-tier-s-bg: rgba(249, 115, 22, 0.22);
+  --dp-tier-s-fg: #fdba74;
+  --dp-tier-a-bg: rgba(245, 158, 11, 0.22);
+  --dp-tier-a-fg: #fcd34d;
+  --dp-tier-b-bg: rgba(16, 185, 129, 0.22);
+  --dp-tier-b-fg: #6ee7b7;
+
+  --dp-ug-red-bg: rgba(239, 68, 68, 0.20);
+  --dp-ug-red-fg: #fca5a5;
+  --dp-ug-redalt-bg: rgba(239, 68, 68, 0.15);
+  --dp-ug-redalt-fg: #fca5a5;
+  --dp-ug-blue-bg: rgba(59, 130, 246, 0.22);
+  --dp-ug-blue-fg: #93c5fd;
+  --dp-ug-cyan-bg: rgba(6, 182, 212, 0.22);
+  --dp-ug-cyan-fg: #67e8f9;
+  --dp-ug-green-bg: rgba(16, 185, 129, 0.22);
+  --dp-ug-green-fg: #6ee7b7;
+  --dp-ug-purple-bg: rgba(139, 92, 246, 0.22);
+  --dp-ug-purple-fg: #c4b5fd;
+
+  --dp-pub-filled-bg: #6366f1;
+  --dp-pub-filled-fg: #ffffff;
+  --dp-pub-filled-alt-bg: #818cf8;
+  --dp-pub-filled-alt-fg: #0f172a;
+  --dp-pub-outlined-fg: #a5b4fc;
+  --dp-pub-outlined-border: #818cf8;
+  --dp-pub-outlined-alt-fg: #a5b4fc;
+  --dp-pub-outlined-alt-border: #4338ca;
+
+  --dp-beta-bg: rgba(249, 115, 22, 0.22);
+  --dp-beta-fg: #fdba74;
+
+  --dp-banner-ok-bg: rgba(16, 185, 129, 0.18);
+  --dp-banner-ok-fg: #6ee7b7;
+  --dp-banner-err-bg: rgba(239, 68, 68, 0.18);
+  --dp-banner-err-fg: #fca5a5;
+  --dp-banner-warn-bg: rgba(245, 158, 11, 0.18);
+  --dp-banner-warn-fg: #fcd34d;
+  --dp-banner-warn-text: #fcd34d;
+
+  --dp-danger-fg: #fca5a5;
+  --dp-danger-hover-bg: rgba(239, 68, 68, 0.18);
+}


### PR DESCRIPTION
## Summary

- 新增 `src/styles/dp-tokens.css`：把 `/datapoints` `/submit-dp` `/my-dp` 的 pill / badge / banner 颜色抽成 `--dp-*` 语义 token，并在 `[data-theme='dark']` 下用半透明 accent 背景 + 浅色前景做一遍覆写，单点切换暗色模式
- 3 个 `module.css`（`datapoints` / `submit-dp` / `my-dp`）原来硬编码 25+ 处 hex 全部改用 `var(--dp-*)`，grep 之后 0 raw hex
- 通过在 `src/css/custom.css` 顶部 `@import '../styles/dp-tokens.css'` 全局注入，不需要改 `docusaurus.config.js`（已经把 `customCss` 指向 `custom.css`）
- 顺手把几个 11-12px 小字 badge 的前景轻微加深（如 `tierS` `countDomestic` `fundBadge`），浅色模式下也满足 WCAG AA 4.5:1 对比度

## Why

之前 Docusaurus 切到暗色主题后，绿/红/黄/灰这些浅底 pill 几乎看不到内容，而 11px 字号又不到 18pt，对 WCAG 必须 4.5:1。这次一次性把语义颜色统一到 token，后续要再调色或加新的 pill 也是一个文件搞定。

## Test plan

- [x] `npm run build`：`[SUCCESS] Generated static files`（原有 `转码项目.md` 的 broken-link warning 与本 PR 无关）
- [x] `npm run start -- --port 3456`：`/datapoints` `/submit-dp` `/my-dp` 均返回 200
- [x] `curl /styles.css`：确认 `--dp-pill-admit-bg` 在 `:root` 下是 `#d1fae5`、在 `[data-theme='dark']` 下是 `rgba(16,185,129,0.22)`，token 正确进入打包产物
- [x] `grep -E "#[0-9a-fA-F]{3,8}"` 3 个 module.css：0 命中
- [ ] 浏览器人工目测：浅色 / 暗色切换下 pill 文字均可读（建议 reviewer 在合并前再扫一眼）

## Files

- 新增 `src/styles/dp-tokens.css`
- 修改 `src/css/custom.css`（加 `@import`）
- 修改 `src/pages/datapoints.module.css`、`src/pages/submit-dp.module.css`、`src/pages/my-dp.module.css`