### PR TITLE
feat(datapoints): /datapoints 页面 a11y / i18n / SEO / 移动端优化

### DIFF
--- a/src/pages/datapoints.jsx
+++ b/src/pages/datapoints.jsx
@@ -1,22 +1,244 @@
-import React, { useEffect, useMemo, useState, useDeferredValue } from 'react';
+import React, { useEffect, useMemo, useState, useDeferredValue, useRef, useCallback } from 'react';
 import Layout from '@theme/Layout';
 import BrowserOnly from '@docusaurus/BrowserOnly';
+import Head from '@docusaurus/Head';
 import useBaseUrl from '@docusaurus/useBaseUrl';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import { DP_API_BASE, getMe, listDp } from '@site/src/lib/dp/api';
 import styles from './datapoints.module.css';
 
 const PAGE_SIZE = 50;
 const TIER_ORDER = ['SSS', 'SS', 'S', 'A', 'B', 'C', 'D'];
 const RESULT_OPTIONS = ['Admit', 'Reject', 'Waitlist', '默拒', 'Withdraw'];
+const MOBILE_BREAKPOINT = 768;
 
-function Inner() {
+// Pre-hydration / no-JS fallback counts. Refresh when snapshot regenerates.
+const STATIC_COUNTS = { datapoints: 1908, applicants: 317, programs: 280 };
+
+const COPY = {
+  'zh-Hans': {
+    pageTitle: 'DataPoints',
+    pageDesc: 'CS / MSCS 申请历史 DataPoints — 可按学校、Tier、年份、结果、本科背景筛选',
+    headerTitle: 'CS Application DataPoints',
+    metaApplicants: '位申请者',
+    metaPrograms: '个项目',
+    metaDatapoints: '条录取数据',
+    beta: '新版预览 (beta)',
+    dataNote: '注：数据来源于历史 Seatable 归档，个人识别字段（联系方式 / 备注 / 推荐信详情等）已脱敏。',
+    liveToggle: '使用 Live API（实时数据，需后端在线）',
+    liveDegraded: 'Live API 不可达，已降级到本地快照',
+    liveLoading: '正在从 API 拉数据…',
+    loadingData: '加载 DataPoints…',
+    loadFail: '加载数据失败：',
+    searchPlaceholder: '搜索学校 / 项目 / 本科名',
+    searchLabel: '搜索',
+    filterSchool: '学校',
+    filterTier: 'Tier',
+    filterYear: '年份',
+    filterResult: '结果',
+    filterUgCat: '本科类别',
+    filterMajor: '本科专业',
+    filterAll: '全部',
+    gpaLabel: 'GPA',
+    gpaMin: 'min',
+    gpaMax: 'max',
+    clearBtn: '清除筛选',
+    shareBtn: '复制分享链接',
+    shareCopied: '已复制！',
+    summaryMatched: '匹配',
+    summaryRows: '条',
+    summaryPage: '页',
+    sourceLive: 'Live API',
+    sourceLiveDegraded: '快照(降级)',
+    sourceSnapshot: '快照',
+    thResult: '结果',
+    thProgram: '项目',
+    thYear: '年份',
+    thUg: '本科 · 专业',
+    thGpa: 'GPA',
+    thResearch: '科研',
+    thInternship: '实习',
+    thPub: 'Pub',
+    thNotes: '备注',
+    funded: '带奖',
+    finalDest: '最终去向',
+    countDomestic: '国',
+    countOverseas: '外',
+    countLabel: (d, o) => `国内 ${d} 段 / 海外 ${o} 段`,
+    pubP1: '已发表 · 顶会一作',
+    pubPstar: '已发表 · 顶会合作者',
+    pubS1: '在投 · 顶会一作',
+    pubSstar: '在投 · 顶会合作者',
+    notesTitle: '查看备注详情',
+    notesDialog: '备注详情',
+    closeDialog: '关闭',
+    emptyTitle: '没有匹配的数据。',
+    emptyHint: '试着放宽筛选条件：',
+    emptyClearAll: '清除全部筛选',
+    activeFilters: '当前筛选：',
+    pageFirst: '首页',
+    pagePrev: '上一页',
+    pageNext: '下一页',
+    pageLast: '末页',
+    pageFirstAria: '跳到第一页',
+    pagePrevAria: '上一页',
+    pageNextAria: '下一页',
+    pageLastAria: '跳到最后一页',
+    signInGoogle: 'Google 登录',
+    signInGitHub: 'GitHub 登录',
+    signInFailed: '登录失败：',
+    adminLabel: 'admin',
+    cardLabelResult: '结果',
+    cardLabelYear: '年份',
+    cardLabelUg: '本科',
+    cardLabelMajor: '专业',
+    cardLabelGpa: 'GPA',
+    cardLabelResearch: '科研',
+    cardLabelInternship: '实习',
+    cardLabelPub: '论文',
+    cardLabelNotes: '备注',
+  },
+  en: {
+    pageTitle: 'DataPoints',
+    pageDesc: 'CS / MSCS application DataPoints — filterable by school, tier, year, result, and undergrad background',
+    headerTitle: 'CS Application DataPoints',
+    metaApplicants: 'applicants',
+    metaPrograms: 'programs',
+    metaDatapoints: 'datapoints',
+    beta: 'new preview (beta)',
+    dataNote: 'Note: data comes from a historical Seatable archive. Personally identifying fields (contacts / private notes / reference details) have been redacted.',
+    liveToggle: 'Use Live API (real-time, requires backend online)',
+    liveDegraded: 'Live API unreachable — falling back to local snapshot',
+    liveLoading: 'Fetching from API…',
+    loadingData: 'Loading DataPoints…',
+    loadFail: 'Failed to load data: ',
+    searchPlaceholder: 'Search school / program / undergrad',
+    searchLabel: 'Search',
+    filterSchool: 'School',
+    filterTier: 'Tier',
+    filterYear: 'Year',
+    filterResult: 'Result',
+    filterUgCat: 'Undergrad type',
+    filterMajor: 'Undergrad major',
+    filterAll: 'All',
+    gpaLabel: 'GPA',
+    gpaMin: 'min',
+    gpaMax: 'max',
+    clearBtn: 'Clear filters',
+    shareBtn: 'Copy share link',
+    shareCopied: 'Copied!',
+    summaryMatched: 'Matched',
+    summaryRows: 'rows',
+    summaryPage: 'page',
+    sourceLive: 'Live API',
+    sourceLiveDegraded: 'Snapshot (degraded)',
+    sourceSnapshot: 'Snapshot',
+    thResult: 'Result',
+    thProgram: 'Program',
+    thYear: 'Year',
+    thUg: 'Undergrad · Major',
+    thGpa: 'GPA',
+    thResearch: 'Research',
+    thInternship: 'Internship',
+    thPub: 'Pub',
+    thNotes: 'Notes',
+    funded: 'Funded',
+    finalDest: 'Final destination',
+    countDomestic: 'CN',
+    countOverseas: 'Intl',
+    countLabel: (d, o) => `${d} domestic / ${o} overseas`,
+    pubP1: 'Published · top venue, first author',
+    pubPstar: 'Published · top venue, co-author',
+    pubS1: 'Under submission · top venue, first author',
+    pubSstar: 'Under submission · top venue, co-author',
+    notesTitle: 'View notes',
+    notesDialog: 'Notes',
+    closeDialog: 'Close',
+    emptyTitle: 'No matching datapoints.',
+    emptyHint: 'Try relaxing your filters:',
+    emptyClearAll: 'Clear all filters',
+    activeFilters: 'Active filters:',
+    pageFirst: 'First',
+    pagePrev: 'Prev',
+    pageNext: 'Next',
+    pageLast: 'Last',
+    pageFirstAria: 'Go to first page',
+    pagePrevAria: 'Previous page',
+    pageNextAria: 'Next page',
+    pageLastAria: 'Go to last page',
+    signInGoogle: 'Sign in with Google',
+    signInGitHub: 'Sign in with GitHub',
+    signInFailed: 'Sign-in failed: ',
+    adminLabel: 'admin',
+    cardLabelResult: 'Result',
+    cardLabelYear: 'Year',
+    cardLabelUg: 'Undergrad',
+    cardLabelMajor: 'Major',
+    cardLabelGpa: 'GPA',
+    cardLabelResearch: 'Research',
+    cardLabelInternship: 'Internship',
+    cardLabelPub: 'Pub',
+    cardLabelNotes: 'Notes',
+  },
+};
+
+function pickLocale(loc) {
+  return loc === 'en' ? 'en' : 'zh-Hans';
+}
+
+// ---------- URL <-> filter state helpers ----------
+
+const URL_KEYS = ['school', 'tier', 'year', 'result', 'ugCat', 'major', 'gpaMin', 'gpaMax', 'q'];
+
+function readFiltersFromUrl() {
+  if (typeof window === 'undefined') return {};
+  const params = new URLSearchParams(window.location.search);
+  const out = {};
+  for (const k of URL_KEYS) {
+    const v = params.get(k);
+    if (v != null && v !== '') out[k] = v;
+  }
+  return out;
+}
+
+function writeFiltersToUrl(filters) {
+  if (typeof window === 'undefined') return;
+  const params = new URLSearchParams(window.location.search);
+  for (const k of URL_KEYS) {
+    const v = filters[k];
+    if (v === '' || v == null) params.delete(k);
+    else params.set(k, v);
+  }
+  const qs = params.toString();
+  const next = `${window.location.pathname}${qs ? `?${qs}` : ''}${window.location.hash}`;
+  window.history.replaceState(null, '', next);
+}
+
+// ---------- Static SEO shell ----------
+
+function StaticHero({ t, counts }) {
+  return (
+    <header className={styles.header} aria-label="page-header-shell">
+      <div className={styles.headerTop}>
+        <h1>{t.headerTitle}</h1>
+      </div>
+      <p className={styles.meta}>
+        <b>{counts.datapoints}</b> {t.metaDatapoints} · <b>{counts.applicants}</b> {t.metaApplicants} ·{' '}
+        <b>{counts.programs}</b> {t.metaPrograms} · <span className={styles.beta}>{t.beta}</span>
+      </p>
+    </header>
+  );
+}
+
+// ---------- Inner: data load orchestration ----------
+
+function Inner({ t }) {
   const dataUrl = useBaseUrl('/data/dp-snapshot.json');
   const [data, setData] = useState(null);
   const [error, setError] = useState(null);
   const [me, setMe] = useState(null);
   const [meChecked, setMeChecked] = useState(false);
 
-  // Load snapshot for filter-options + client-side filtering (always).
   useEffect(() => {
     fetch(dataUrl)
       .then((r) => {
@@ -27,7 +249,6 @@ function Inner() {
       .catch((e) => setError(String(e)));
   }, [dataUrl]);
 
-  // Probe the live API for session state.
   useEffect(() => {
     let cancelled = false;
     getMe()
@@ -41,15 +262,13 @@ function Inner() {
     return () => { cancelled = true; };
   }, []);
 
-  if (error) return <div className={styles.errorBox}>加载数据失败：{error}</div>;
-  if (!data) return <div className={styles.loading}>加载 DataPoints…</div>;
-  return <Table data={data} me={me} meChecked={meChecked} />;
+  if (error) return <div className={styles.errorBox}>{t.loadFail}{error}</div>;
+  if (!data) return <div className={styles.loading}>{t.loadingData}</div>;
+  return <Table data={data} me={me} meChecked={meChecked} t={t} />;
 }
 
-function SignInButton() {
+function SignInButton({ t }) {
   async function signIn(provider) {
-    // better-auth expects POST /api/auth/sign-in/social with JSON body; it
-    // returns { url, redirect } where url is the provider's consent page.
     const callbackURL = window.location.href;
     try {
       const r = await fetch(`${DP_API_BASE}/api/auth/sign-in/social`, {
@@ -62,37 +281,52 @@ function SignInButton() {
       if (data.url) {
         window.location.href = data.url;
       } else {
-        alert(`登录失败：${data.message || 'unknown error'}`);
+        alert(`${t.signInFailed}${data.message || 'unknown error'}`);
       }
     } catch (e) {
-      alert(`登录失败：${e.message}`);
+      alert(`${t.signInFailed}${e.message}`);
     }
   }
   return (
     <span className={styles.signInGroup}>
-      <button className={styles.signInBtn} onClick={() => signIn('google')}>Google 登录</button>
-      <button className={styles.signInBtn} onClick={() => signIn('github')}>GitHub 登录</button>
+      <button className={styles.signInBtn} onClick={() => signIn('google')}>{t.signInGoogle}</button>
+      <button className={styles.signInBtn} onClick={() => signIn('github')}>{t.signInGitHub}</button>
     </span>
   );
 }
 
-function MeBadge({ me }) {
+function MeBadge({ me, t }) {
   return (
     <span className={styles.meBadge}>
-      👤 {me.nickname}{me.role === 'admin' ? ' · admin' : ''}
+      <span aria-hidden="true">👤 </span>{me.nickname}{me.role === 'admin' ? ` · ${t.adminLabel}` : ''}
     </span>
   );
 }
 
-function Table({ data, me, meChecked }) {
+// ---------- Mobile viewport detection ----------
+
+function useIsMobile() {
+  const [isMobile, setIsMobile] = useState(false);
+  useEffect(() => {
+    const check = () => setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+    check();
+    window.addEventListener('resize', check);
+    return () => window.removeEventListener('resize', check);
+  }, []);
+  return isMobile;
+}
+
+// ---------- Main Table component ----------
+
+function Table({ data, me, meChecked, t }) {
   const { applicants, programs, datapoints } = data;
   const [useLiveApi, setUseLiveApi] = useState(false);
   const [liveRows, setLiveRows] = useState(null);
   const [liveTotal, setLiveTotal] = useState(0);
   const [liveLoading, setLiveLoading] = useState(false);
   const [liveError, setLiveError] = useState(null);
+  const isMobile = useIsMobile();
 
-  // ---------- enumerate filter options from data ----------
   const filterOpts = useMemo(() => {
     const schools = new Set();
     const tiers = new Set();
@@ -112,28 +346,31 @@ function Table({ data, me, meChecked }) {
     }
     return {
       schools: [...schools].sort(),
-      tiers: TIER_ORDER.filter((t) => tiers.has(t)),
+      tiers: TIER_ORDER.filter((x) => tiers.has(x)),
       years: [...years].sort((a, b) => b - a),
       ugCats: [...ugCats].sort(),
       majors: [...majors].sort(),
     };
   }, [applicants, programs, datapoints]);
 
-  // ---------- filter state ----------
-  const [school, setSchool] = useState('');
-  const [tier, setTier] = useState('');
-  const [year, setYear] = useState('');
-  const [result, setResult] = useState('');
-  const [ugCat, setUgCat] = useState('');
-  const [major, setMajor] = useState('');
-  const [gpaMin, setGpaMin] = useState('');
-  const [gpaMax, setGpaMax] = useState('');
-  const [query, setQuery] = useState('');
+  const initial = useMemo(() => readFiltersFromUrl(), []);
+  const [school, setSchool] = useState(initial.school || '');
+  const [tier, setTier] = useState(initial.tier || '');
+  const [year, setYear] = useState(initial.year || '');
+  const [result, setResult] = useState(initial.result || '');
+  const [ugCat, setUgCat] = useState(initial.ugCat || '');
+  const [major, setMajor] = useState(initial.major || '');
+  const [gpaMin, setGpaMin] = useState(initial.gpaMin || '');
+  const [gpaMax, setGpaMax] = useState(initial.gpaMax || '');
+  const [query, setQuery] = useState(initial.q || '');
   const [page, setPage] = useState(0);
 
   const deferredQuery = useDeferredValue(query);
 
-  // ---------- joined + filtered rows ----------
+  useEffect(() => {
+    writeFiltersToUrl({ school, tier, year, result, ugCat, major, gpaMin, gpaMax, q: deferredQuery });
+  }, [school, tier, year, result, ugCat, major, gpaMin, gpaMax, deferredQuery]);
+
   const rows = useMemo(() => {
     const q = deferredQuery.trim().toLowerCase();
     const gMin = gpaMin === '' ? null : Number(gpaMin);
@@ -164,23 +401,12 @@ function Table({ data, me, meChecked }) {
     });
     return out;
   }, [
-    datapoints,
-    programs,
-    applicants,
-    school,
-    tier,
-    year,
-    result,
-    ugCat,
-    major,
-    gpaMin,
-    gpaMax,
-    deferredQuery,
+    datapoints, programs, applicants,
+    school, tier, year, result, ugCat, major, gpaMin, gpaMax, deferredQuery,
   ]);
 
   useEffect(() => setPage(0), [school, tier, year, result, ugCat, major, gpaMin, gpaMax, deferredQuery, useLiveApi]);
 
-  // ---------- live-API mode: fetch from /api/dp on filter change ----------
   useEffect(() => {
     if (!useLiveApi) {
       setLiveRows(null);
@@ -207,223 +433,387 @@ function Table({ data, me, meChecked }) {
         setLiveRows(res.rows);
         setLiveTotal(res.total);
         if (res.source === 'snapshot') {
-          setLiveError('Live API 不可达，已降级到本地快照');
+          setLiveError(t.liveDegraded);
         }
       } catch (e) {
         setLiveError(String(e));
       } finally {
         setLiveLoading(false);
       }
-    }, 250); // debounce
+    }, 250);
     return () => clearTimeout(handle);
-  }, [useLiveApi, school, tier, year, result, ugCat, major, gpaMin, gpaMax, deferredQuery, page]);
+  }, [useLiveApi, school, tier, year, result, ugCat, major, gpaMin, gpaMax, deferredQuery, page, t]);
 
-  // ---------- compose final rows + total based on mode ----------
   const totalCount = useLiveApi ? liveTotal : rows.length;
   const totalPages = Math.max(1, Math.ceil(totalCount / PAGE_SIZE));
   const paged = useLiveApi
     ? (liveRows || [])
     : rows.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE);
 
-  function clear() {
-    setSchool('');
-    setTier('');
-    setYear('');
-    setResult('');
-    setUgCat('');
-    setMajor('');
-    setGpaMin('');
-    setGpaMax('');
+  const clear = useCallback(() => {
+    setSchool(''); setTier(''); setYear(''); setResult('');
+    setUgCat(''); setMajor(''); setGpaMin(''); setGpaMax('');
     setQuery('');
-  }
+  }, []);
+
+  const activeFilters = useMemo(() => {
+    const items = [];
+    if (school) items.push({ key: 'school', label: t.filterSchool, value: school });
+    if (tier) items.push({ key: 'tier', label: t.filterTier, value: tier });
+    if (year) items.push({ key: 'year', label: t.filterYear, value: year });
+    if (result) items.push({ key: 'result', label: t.filterResult, value: result });
+    if (ugCat) items.push({ key: 'ugCat', label: t.filterUgCat, value: ugCat });
+    if (major) items.push({ key: 'major', label: t.filterMajor, value: major });
+    if (gpaMin) items.push({ key: 'gpaMin', label: `${t.gpaLabel} ${t.gpaMin}`, value: gpaMin });
+    if (gpaMax) items.push({ key: 'gpaMax', label: `${t.gpaLabel} ${t.gpaMax}`, value: gpaMax });
+    if (deferredQuery) items.push({ key: 'q', label: t.searchLabel, value: deferredQuery });
+    return items;
+  }, [school, tier, year, result, ugCat, major, gpaMin, gpaMax, deferredQuery, t]);
+
+  const [copied, setCopied] = useState(false);
+  const copyShare = useCallback(() => {
+    if (typeof window === 'undefined') return;
+    const url = window.location.href;
+    const finish = () => { setCopied(true); setTimeout(() => setCopied(false), 1600); };
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(url).then(finish).catch(finish);
+    } else {
+      finish();
+    }
+  }, []);
 
   return (
     <div className={styles.wrap}>
       <header className={styles.header}>
         <div className={styles.headerTop}>
-          <h1>CS Application DataPoints</h1>
+          <h1>{t.headerTitle}</h1>
           <div className={styles.headerRight}>
-            {meChecked && (me ? <MeBadge me={me} /> : <SignInButton />)}
+            {meChecked && (me ? <MeBadge me={me} t={t} /> : <SignInButton t={t} />)}
           </div>
         </div>
         <p className={styles.meta}>
-          共 <b>{data.counts.applicants}</b> 位申请者 · <b>{data.counts.programs}</b> 个项目 ·{' '}
-          <b>{data.counts.datapoints}</b> 条录取数据 ·{' '}
-          <span className={styles.beta}>新版预览 (beta)</span>
+          <b>{data.counts.datapoints}</b> {t.metaDatapoints} · <b>{data.counts.applicants}</b> {t.metaApplicants} ·{' '}
+          <b>{data.counts.programs}</b> {t.metaPrograms} · <span className={styles.beta}>{t.beta}</span>
         </p>
         <p className={styles.note}>
-          注：数据来源于历史 Seatable 归档，个人识别字段（联系方式 / 备注 / 推荐信详情等）已脱敏。
+          {t.dataNote}
           <label className={styles.liveToggle}>
             <input
               type="checkbox"
               checked={useLiveApi}
               onChange={(e) => setUseLiveApi(e.target.checked)}
             />
-            <span>使用 Live API（实时数据，需后端在线）</span>
+            <span>{t.liveToggle}</span>
           </label>
         </p>
-        {useLiveApi && liveError ? <p className={styles.liveErr}>⚠️ {liveError}</p> : null}
-        {useLiveApi && liveLoading ? <p className={styles.note}>正在从 API 拉数据…</p> : null}
+        {useLiveApi && liveError ? <p className={styles.liveErr} role="status"><span aria-hidden="true">⚠️ </span>{liveError}</p> : null}
+        {useLiveApi && liveLoading ? <p className={styles.note}>{t.liveLoading}</p> : null}
       </header>
 
-      <section className={styles.filters}>
+      <section className={styles.filters} aria-label={t.searchLabel}>
         <input
           className={styles.search}
-          placeholder="搜索学校 / 项目 / 本科名"
+          type="search"
+          placeholder={t.searchPlaceholder}
           value={query}
           onChange={(e) => setQuery(e.target.value)}
+          aria-label={t.searchLabel}
         />
-        <Select label="学校" value={school} onChange={setSchool} options={filterOpts.schools} />
-        <Select label="Tier" value={tier} onChange={setTier} options={filterOpts.tiers} />
-        <Select label="年份" value={year} onChange={setYear} options={filterOpts.years} />
-        <Select label="结果" value={result} onChange={setResult} options={RESULT_OPTIONS} />
-        <Select label="本科类别" value={ugCat} onChange={setUgCat} options={filterOpts.ugCats} />
-        <Select label="本科专业" value={major} onChange={setMajor} options={filterOpts.majors} />
-        <div className={styles.gpaRange}>
-          <span>GPA</span>
+        <Select label={t.filterSchool} value={school} onChange={setSchool} options={filterOpts.schools} allText={t.filterAll} />
+        <Select label={t.filterTier} value={tier} onChange={setTier} options={filterOpts.tiers} allText={t.filterAll} />
+        <Select label={t.filterYear} value={year} onChange={setYear} options={filterOpts.years} allText={t.filterAll} />
+        <Select label={t.filterResult} value={result} onChange={setResult} options={RESULT_OPTIONS} allText={t.filterAll} />
+        <Select label={t.filterUgCat} value={ugCat} onChange={setUgCat} options={filterOpts.ugCats} allText={t.filterAll} />
+        <Select label={t.filterMajor} value={major} onChange={setMajor} options={filterOpts.majors} allText={t.filterAll} />
+        <div className={styles.gpaRange} role="group" aria-label={t.gpaLabel}>
+          <span aria-hidden="true">{t.gpaLabel}</span>
           <input
             type="number"
             step="0.01"
-            placeholder="min"
+            placeholder={t.gpaMin}
             value={gpaMin}
             onChange={(e) => setGpaMin(e.target.value)}
+            aria-label={`${t.gpaLabel} ${t.gpaMin}`}
           />
-          <span>–</span>
+          <span aria-hidden="true">–</span>
           <input
             type="number"
             step="0.01"
-            placeholder="max"
+            placeholder={t.gpaMax}
             value={gpaMax}
             onChange={(e) => setGpaMax(e.target.value)}
+            aria-label={`${t.gpaLabel} ${t.gpaMax}`}
           />
         </div>
-        <button className={styles.clearBtn} onClick={clear}>
-          清除筛选
+        <button className={styles.clearBtn} onClick={clear} type="button">
+          {t.clearBtn}
+        </button>
+        <button
+          className={styles.clearBtn}
+          onClick={copyShare}
+          type="button"
+          aria-label={t.shareBtn}
+          style={{ marginLeft: 4 }}
+        >
+          {copied ? t.shareCopied : t.shareBtn}
         </button>
       </section>
 
-      <div className={styles.summary}>
-        匹配 <b>{totalCount}</b> 条 · 第 {page + 1} / {totalPages} 页 ·{' '}
+      <div className={styles.summary} role="status" aria-live="polite">
+        {t.summaryMatched} <b>{totalCount}</b> {t.summaryRows} · {page + 1} / {totalPages} {t.summaryPage} ·{' '}
         <span className={styles.sourceBadge}>
-          {useLiveApi ? (liveError ? '快照(降级)' : 'Live API') : '快照'}
+          {useLiveApi ? (liveError ? t.sourceLiveDegraded : t.sourceLive) : t.sourceSnapshot}
         </span>
       </div>
 
-      <div className={styles.tableWrap}>
-        <table className={styles.table}>
-          <thead>
-            <tr>
-              <th>结果</th>
-              <th>项目</th>
-              <th>年份</th>
-              <th>本科 · 专业</th>
-              <th>GPA</th>
-              <th>科研</th>
-              <th>实习</th>
-              <th>Pub</th>
-              <th>备注</th>
-            </tr>
-          </thead>
-          <tbody>
-            {paged.map(({ d, p, a }) => (
-              <tr key={d.id}>
-                <td className={styles.resultCell}>
-                  <span className={`${styles.pill} ${pillClass(d.result)}`}>{d.result || '—'}</span>
-                  {d.is_funded ? <span className={styles.fundBadge} title="带奖">奖</span> : null}
-                  {d.is_final_destination ? <span className={styles.finalBadge} title="最终去向">最终</span> : null}
-                </td>
-                <td className={styles.programCell}>
-                  <div className={styles.schoolName}>{p.school}</div>
-                  <div className={styles.programName}>
-                    {p.program}
-                    {p.tier ? <span className={`${styles.tierBadge} ${tierBadgeClass(p.tier)}`}>{p.tier}</span> : null}
-                  </div>
-                </td>
-                <td className={styles.yearCell}>
-                  <div>{d.academic_year || '—'}</div>
-                  <div className={styles.muted}>{d.semester || ''}</div>
-                  {d.notified_at ? <div className={styles.smallMuted}>{d.notified_at}</div> : null}
-                </td>
-                <td className={styles.ugCell}>
-                  <div className={styles.ugRow}>
-                    {a.ug_school_category ? (
-                      <span className={`${styles.ugCatBadge} ${ugCatBadgeClass(a.ug_school_category)}`}>
-                        {a.ug_school_category}
-                      </span>
-                    ) : null}
-                    <span className={styles.ugName}>{a.ug_school_name || ''}</span>
-                  </div>
-                  {a.ug_major ? <div className={styles.majorTag}>{a.ug_major}</div> : null}
-                </td>
-                <td className={styles.gpaCell}>
-                  {a.gpa != null ? (
-                    <>
-                      <span className={styles.gpaValue}>{a.gpa}</span>
-                      <span className={styles.muted}>/{a.gpa_scale}</span>
-                      {a.gpa_rank ? <div className={styles.gpaRank}>{a.gpa_rank}</div> : null}
-                    </>
-                  ) : (
-                    <span className={styles.muted}>—</span>
-                  )}
-                </td>
-                <td className={styles.countCell}>
-                  <CountInlineBadges
-                    domestic={a.research_domestic_count}
-                    overseas={a.research_overseas_count}
-                  />
-                </td>
-                <td className={styles.countCell}>
-                  <CountInlineBadges
-                    domestic={a.internship_domestic_count}
-                    overseas={a.internship_overseas_count}
-                  />
-                </td>
-                <td className={styles.pubCell}>
-                  <PubBadges a={a} />
-                </td>
-                <td className={styles.notesCell}>
-                  <NotesCell d={d} a={a} />
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-        {rows.length === 0 ? (
-          <div className={styles.empty}>没有匹配的数据。试着放宽筛选条件。</div>
-        ) : null}
-      </div>
+      {paged.length === 0 ? (
+        <EmptyState t={t} activeFilters={activeFilters} onClear={clear} />
+      ) : isMobile ? (
+        <MobileCards rows={paged} t={t} />
+      ) : (
+        <DesktopTable rows={paged} t={t} />
+      )}
 
-      <div className={styles.pager}>
-        <button disabled={page === 0} onClick={() => setPage(0)}>
-          « 首页
+      <nav className={styles.pager} aria-label="pagination">
+        <button
+          disabled={page === 0}
+          onClick={() => setPage(0)}
+          aria-label={t.pageFirstAria}
+          type="button"
+        >
+          <span aria-hidden="true">« </span>{t.pageFirst}
         </button>
-        <button disabled={page === 0} onClick={() => setPage((p) => p - 1)}>
-          ‹ 上一页
+        <button
+          disabled={page === 0}
+          onClick={() => setPage((p) => p - 1)}
+          aria-label={t.pagePrevAria}
+          type="button"
+        >
+          <span aria-hidden="true">‹ </span>{t.pagePrev}
         </button>
-        <span>
+        <span aria-live="polite">
           {page + 1} / {totalPages}
         </span>
-        <button disabled={page >= totalPages - 1} onClick={() => setPage((p) => p + 1)}>
-          下一页 ›
+        <button
+          disabled={page >= totalPages - 1}
+          onClick={() => setPage((p) => p + 1)}
+          aria-label={t.pageNextAria}
+          type="button"
+        >
+          {t.pageNext}<span aria-hidden="true"> ›</span>
         </button>
-        <button disabled={page >= totalPages - 1} onClick={() => setPage(totalPages - 1)}>
-          末页 »
+        <button
+          disabled={page >= totalPages - 1}
+          onClick={() => setPage(totalPages - 1)}
+          aria-label={t.pageLastAria}
+          type="button"
+        >
+          {t.pageLast}<span aria-hidden="true"> »</span>
         </button>
-      </div>
+      </nav>
     </div>
   );
 }
 
-function Select({ label, value, onChange, options }) {
+// ---------- Empty state ----------
+
+function EmptyState({ t, activeFilters, onClear }) {
+  return (
+    <div className={styles.empty} role="status">
+      <div style={{ fontWeight: 600, marginBottom: 8 }}>{t.emptyTitle}</div>
+      {activeFilters.length > 0 ? (
+        <>
+          <div style={{ marginBottom: 6 }}>{t.activeFilters}</div>
+          <ul style={{ display: 'flex', gap: 6, flexWrap: 'wrap', listStyle: 'none', padding: 0, margin: '0 0 12px' }}>
+            {activeFilters.map((f) => (
+              <li key={f.key} style={{ background: 'var(--ifm-color-emphasis-100)', padding: '3px 8px', borderRadius: 4, fontSize: 13 }}>
+                <b>{f.label}:</b> {f.value}
+              </li>
+            ))}
+          </ul>
+        </>
+      ) : (
+        <div style={{ marginBottom: 12 }}>{t.emptyHint}</div>
+      )}
+      <button className={styles.clearBtn} onClick={onClear} type="button">
+        {t.emptyClearAll}
+      </button>
+    </div>
+  );
+}
+
+// ---------- Desktop table ----------
+
+function DesktopTable({ rows, t }) {
+  return (
+    <div className={styles.tableWrap}>
+      <table className={styles.table}>
+        <thead>
+          <tr>
+            <th scope="col">{t.thResult}</th>
+            <th scope="col">{t.thProgram}</th>
+            <th scope="col">{t.thYear}</th>
+            <th scope="col">{t.thUg}</th>
+            <th scope="col">{t.thGpa}</th>
+            <th scope="col">{t.thResearch}</th>
+            <th scope="col">{t.thInternship}</th>
+            <th scope="col">{t.thPub}</th>
+            <th scope="col">{t.thNotes}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map(({ d, p, a }) => (
+            <tr key={d.id}>
+              <td className={styles.resultCell}>
+                <ResultPills d={d} t={t} />
+              </td>
+              <td className={styles.programCell}>
+                <div className={styles.schoolName}>{p.school}</div>
+                <div className={styles.programName}>
+                  {p.program}
+                  {p.tier ? <span className={`${styles.tierBadge} ${tierBadgeClass(p.tier)}`} aria-label={`Tier ${p.tier}`}>{p.tier}</span> : null}
+                </div>
+              </td>
+              <td className={styles.yearCell}>
+                <div>{d.academic_year || '—'}</div>
+                <div className={styles.muted}>{d.semester || ''}</div>
+                {d.notified_at ? <div className={styles.smallMuted}>{d.notified_at}</div> : null}
+              </td>
+              <td className={styles.ugCell}>
+                <div className={styles.ugRow}>
+                  {a.ug_school_category ? (
+                    <span className={`${styles.ugCatBadge} ${ugCatBadgeClass(a.ug_school_category)}`}>
+                      {a.ug_school_category}
+                    </span>
+                  ) : null}
+                  <span className={styles.ugName}>{a.ug_school_name || ''}</span>
+                </div>
+                {a.ug_major ? <div className={styles.majorTag}>{a.ug_major}</div> : null}
+              </td>
+              <td className={styles.gpaCell}>
+                <GpaCell a={a} />
+              </td>
+              <td className={styles.countCell}>
+                <CountInlineBadges domestic={a.research_domestic_count} overseas={a.research_overseas_count} t={t} />
+              </td>
+              <td className={styles.countCell}>
+                <CountInlineBadges domestic={a.internship_domestic_count} overseas={a.internship_overseas_count} t={t} />
+              </td>
+              <td className={styles.pubCell}>
+                <PubBadges a={a} t={t} />
+              </td>
+              <td className={styles.notesCell}>
+                <NotesCell d={d} a={a} t={t} />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ---------- Mobile card layout ----------
+
+function MobileCards({ rows, t }) {
+  const card = {
+    border: '1px solid var(--ifm-color-emphasis-200)',
+    borderRadius: 8,
+    padding: 12,
+    marginBottom: 10,
+    background: 'var(--ifm-background-surface-color, transparent)',
+  };
+  const row = { display: 'flex', justifyContent: 'space-between', gap: 8, marginTop: 6, fontSize: 14 };
+  const labelStyle = { color: 'var(--ifm-color-emphasis-600)', flexShrink: 0 };
+  return (
+    <div style={{ marginBottom: 16 }}>
+      {rows.map(({ d, p, a }) => (
+        <article key={d.id} style={card}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 8 }}>
+            <div style={{ fontWeight: 600 }}>{p.school}</div>
+            <ResultPills d={d} t={t} />
+          </div>
+          <div style={{ marginTop: 4, fontSize: 14 }}>
+            {p.program}
+            {p.tier ? <span className={`${styles.tierBadge} ${tierBadgeClass(p.tier)}`} aria-label={`Tier ${p.tier}`} style={{ marginLeft: 6 }}>{p.tier}</span> : null}
+          </div>
+          <div style={row}>
+            <span style={labelStyle}>{t.cardLabelYear}</span>
+            <span>{d.academic_year || '—'} {d.semester || ''}</span>
+          </div>
+          <div style={row}>
+            <span style={labelStyle}>{t.cardLabelUg}</span>
+            <span style={{ textAlign: 'right' }}>
+              {a.ug_school_category ? (
+                <span className={`${styles.ugCatBadge} ${ugCatBadgeClass(a.ug_school_category)}`} style={{ marginRight: 4 }}>
+                  {a.ug_school_category}
+                </span>
+              ) : null}
+              {a.ug_school_name || ''}
+              {a.ug_major ? <div className={styles.majorTag}>{a.ug_major}</div> : null}
+            </span>
+          </div>
+          <div style={row}>
+            <span style={labelStyle}>{t.cardLabelGpa}</span>
+            <span><GpaCell a={a} /></span>
+          </div>
+          <div style={row}>
+            <span style={labelStyle}>{t.cardLabelResearch}</span>
+            <span><CountInlineBadges domestic={a.research_domestic_count} overseas={a.research_overseas_count} t={t} /></span>
+          </div>
+          <div style={row}>
+            <span style={labelStyle}>{t.cardLabelInternship}</span>
+            <span><CountInlineBadges domestic={a.internship_domestic_count} overseas={a.internship_overseas_count} t={t} /></span>
+          </div>
+          <div style={row}>
+            <span style={labelStyle}>{t.cardLabelPub}</span>
+            <span><PubBadges a={a} t={t} /></span>
+          </div>
+          <div style={{ ...row, alignItems: 'flex-start' }}>
+            <span style={labelStyle}>{t.cardLabelNotes}</span>
+            <span style={{ textAlign: 'right', maxWidth: '70%' }}><NotesCell d={d} a={a} t={t} /></span>
+          </div>
+        </article>
+      ))}
+    </div>
+  );
+}
+
+// ---------- Small presentational helpers ----------
+
+function ResultPills({ d, t }) {
+  return (
+    <>
+      <span className={`${styles.pill} ${pillClass(d.result)}`}>{d.result || '—'}</span>
+      {d.is_funded ? (
+        <span className={styles.fundBadge} role="img" aria-label={t.funded} title={t.funded}>奖</span>
+      ) : null}
+      {d.is_final_destination ? (
+        <span className={styles.finalBadge} role="img" aria-label={t.finalDest} title={t.finalDest}>最终</span>
+      ) : null}
+    </>
+  );
+}
+
+function GpaCell({ a }) {
+  if (a.gpa == null) return <span className={styles.muted}>—</span>;
+  return (
+    <>
+      <span className={styles.gpaValue}>{a.gpa}</span>
+      <span className={styles.muted}>/{a.gpa_scale}</span>
+      {a.gpa_rank ? <div className={styles.gpaRank}>{a.gpa_rank}</div> : null}
+    </>
+  );
+}
+
+function Select({ label, value, onChange, options, allText }) {
   return (
     <label className={styles.selectWrap}>
       <span>{label}</span>
-      <select value={value} onChange={(e) => onChange(e.target.value)}>
-        <option value="">全部</option>
+      <select value={value} onChange={(e) => onChange(e.target.value)} aria-label={label}>
+        <option value="">{allText}</option>
         {options.map((o) => (
-          <option key={o} value={o}>
-            {o}
-          </option>
+          <option key={o} value={o}>{o}</option>
         ))}
       </select>
     </label>
@@ -432,17 +822,12 @@ function Select({ label, value, onChange, options }) {
 
 function pillClass(result) {
   switch (result) {
-    case 'Admit':
-      return styles.pillAdmit;
+    case 'Admit': return styles.pillAdmit;
     case 'Reject':
-    case '默拒':
-      return styles.pillReject;
-    case 'Waitlist':
-      return styles.pillWait;
-    case 'Withdraw':
-      return styles.pillWithdraw;
-    default:
-      return styles.pillUnknown;
+    case '默拒': return styles.pillReject;
+    case 'Waitlist': return styles.pillWait;
+    case 'Withdraw': return styles.pillWithdraw;
+    default: return styles.pillUnknown;
   }
 }
 
@@ -458,41 +843,41 @@ function tierBadgeClass(tier) {
 }
 
 function ugCatBadgeClass(cat) {
-  // Heuristic groupings that map similar categories to similar colors.
   if (cat === '清北') return styles.ugRed;
   if (cat === '华五' || cat === '国科/上科/南科') return styles.ugRedAlt;
   if (cat === '10043' || cat === '985') return styles.ugBlue;
   if (cat === '211') return styles.ugCyan;
   if (cat === '双非' || cat === '陆本') return styles.ugGray;
   if (cat === '美本' || cat === '加本' || cat === '英本' || cat === '澳本' || cat === '港本' || cat === '坡本' || cat === '欧陆本' || cat === '海本') return styles.ugGreen;
-  return styles.ugPurple; // 中外合办/JV
+  return styles.ugPurple;
 }
 
-function CountInlineBadges({ domestic, overseas }) {
+function CountInlineBadges({ domestic, overseas, t }) {
   const d = domestic ?? 0;
   const o = overseas ?? 0;
   if (d === 0 && o === 0) return <span className={styles.muted}>—</span>;
+  const label = t.countLabel(d, o);
   return (
-    <span className={styles.countBadges} title={`国内 ${d} 段 / 海外 ${o} 段`}>
-      <span className={styles.countDomestic}>国 {d}</span>
-      <span className={styles.countOverseas}>外 {o}</span>
+    <span className={styles.countBadges} title={label} aria-label={label}>
+      <span className={styles.countDomestic}>{t.countDomestic} {d}</span>
+      <span className={styles.countOverseas}>{t.countOverseas} {o}</span>
     </span>
   );
 }
 
-function PubBadges({ a }) {
+function PubBadges({ a, t }) {
   const items = [
-    { on: a.pub_top_first_author, label: 'P1', cls: styles.pubFilled, title: '已发表 · 顶会一作' },
-    { on: a.pub_top_other_author, label: 'P*', cls: styles.pubFilledAlt, title: '已发表 · 顶会合作者' },
-    { on: a.submission_top_first_author, label: 'S1', cls: styles.pubOutlined, title: '在投 · 顶会一作' },
-    { on: a.submission_top_other_author, label: 'S*', cls: styles.pubOutlinedAlt, title: '在投 · 顶会合作者' },
+    { on: a.pub_top_first_author, label: 'P1', cls: styles.pubFilled, title: t.pubP1 },
+    { on: a.pub_top_other_author, label: 'P*', cls: styles.pubFilledAlt, title: t.pubPstar },
+    { on: a.submission_top_first_author, label: 'S1', cls: styles.pubOutlined, title: t.pubS1 },
+    { on: a.submission_top_other_author, label: 'S*', cls: styles.pubOutlinedAlt, title: t.pubSstar },
   ];
   const active = items.filter((x) => x.on);
   if (active.length === 0) return <span className={styles.muted}>—</span>;
   return (
     <span className={styles.pubBadges}>
       {active.map((x) => (
-        <span key={x.label} className={`${styles.pubBadge} ${x.cls}`} title={x.title}>
+        <span key={x.label} className={`${styles.pubBadge} ${x.cls}`} title={x.title} aria-label={x.title}>
           {x.label}
         </span>
       ))}
@@ -500,32 +885,147 @@ function PubBadges({ a }) {
   );
 }
 
-function NotesCell({ d, a }) {
-  const parts = [];
-  if (d.notes) parts.push(['📝', d.notes]);
-  if (a.research_notes) parts.push(['🔬', a.research_notes]);
-  if (a.internship_notes) parts.push(['💼', a.internship_notes]);
-  if (a.pub_notes) parts.push(['📄', a.pub_notes]);
-  if (a.rec_notes) parts.push(['✉️', a.rec_notes]);
-  if (a.other_soft_background) parts.push(['✨', a.other_soft_background]);
-  if (a.education_notes) parts.push(['🎓', a.education_notes]);
+// Click-to-expand dialog; keeps `title=` so non-JS / hover users still see content.
+function NotesCell({ d, a, t }) {
+  const parts = useMemo(() => {
+    const out = [];
+    if (d.notes) out.push(['📝', d.notes]);
+    if (a.research_notes) out.push(['🔬', a.research_notes]);
+    if (a.internship_notes) out.push(['💼', a.internship_notes]);
+    if (a.pub_notes) out.push(['📄', a.pub_notes]);
+    if (a.rec_notes) out.push(['✉️', a.rec_notes]);
+    if (a.other_soft_background) out.push(['✨', a.other_soft_background]);
+    if (a.education_notes) out.push(['🎓', a.education_notes]);
+    return out;
+  }, [d, a]);
+
+  const [open, setOpen] = useState(false);
+  const dialogRef = useRef(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e) => { if (e.key === 'Escape') setOpen(false); };
+    window.addEventListener('keydown', onKey);
+    const timer = setTimeout(() => {
+      dialogRef.current?.querySelector('[data-close]')?.focus();
+    }, 0);
+    return () => {
+      window.removeEventListener('keydown', onKey);
+      clearTimeout(timer);
+    };
+  }, [open]);
+
   if (parts.length === 0) return <span className={styles.muted}>—</span>;
-  // Show first 60 chars of first note; reveal full set on hover (title attr
-  // shows everything for now; can swap to a popover later).
   const fullText = parts.map(([icon, text]) => `${icon} ${text}`).join('\n\n');
   const preview = parts[0][1].slice(0, 60) + (parts[0][1].length > 60 || parts.length > 1 ? '…' : '');
+
   return (
-    <span className={styles.notesPreview} title={fullText}>
-      {parts[0][0]} {preview}
-      {parts.length > 1 ? <span className={styles.moreNotes}> +{parts.length - 1}</span> : null}
-    </span>
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        title={fullText}
+        aria-label={t.notesTitle}
+        aria-haspopup="dialog"
+        style={{
+          background: 'transparent',
+          border: 0,
+          padding: 0,
+          font: 'inherit',
+          color: 'inherit',
+          cursor: 'pointer',
+          textAlign: 'left',
+        }}
+        className={styles.notesPreview}
+      >
+        <span aria-hidden="true">{parts[0][0]} </span>{preview}
+        {parts.length > 1 ? <span className={styles.moreNotes}> +{parts.length - 1}</span> : null}
+      </button>
+      {open ? (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label={t.notesDialog}
+          onClick={() => setOpen(false)}
+          style={{
+            position: 'fixed',
+            inset: 0,
+            background: 'rgba(0,0,0,0.45)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            zIndex: 1000,
+            padding: 16,
+          }}
+        >
+          <div
+            ref={dialogRef}
+            onClick={(e) => e.stopPropagation()}
+            style={{
+              background: 'var(--ifm-background-surface-color, #fff)',
+              color: 'var(--ifm-font-color-base)',
+              borderRadius: 8,
+              maxWidth: 600,
+              width: '100%',
+              maxHeight: '80vh',
+              overflow: 'auto',
+              padding: 20,
+              boxShadow: '0 10px 30px rgba(0,0,0,0.25)',
+            }}
+          >
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>
+              <h3 style={{ margin: 0 }}>{t.notesDialog}</h3>
+              <button
+                data-close
+                type="button"
+                onClick={() => setOpen(false)}
+                aria-label={t.closeDialog}
+                style={{
+                  background: 'transparent',
+                  border: '1px solid var(--ifm-color-emphasis-300)',
+                  borderRadius: 4,
+                  padding: '4px 10px',
+                  cursor: 'pointer',
+                }}
+              >
+                {t.closeDialog} ✕
+              </button>
+            </div>
+            <div>
+              {parts.map(([icon, text], i) => (
+                <div key={i} style={{ marginBottom: 12, whiteSpace: 'pre-wrap', lineHeight: 1.5 }}>
+                  <span aria-hidden="true" style={{ marginRight: 6 }}>{icon}</span>
+                  {text}
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </>
   );
 }
 
+// ---------- Page entry ----------
+
 export default function DataPointsPage() {
+  const { i18n } = useDocusaurusContext();
+  const locale = pickLocale(i18n.currentLocale);
+  const t = COPY[locale];
   return (
-    <Layout title="DataPoints" description="CS application DataPoints with filters">
-      <BrowserOnly>{() => <Inner />}</BrowserOnly>
+    <Layout title={t.pageTitle} description={t.pageDesc}>
+      <Head>
+        <meta name="description" content={t.pageDesc} />
+        <meta property="og:title" content={t.pageTitle} />
+        <meta property="og:description" content={t.pageDesc} />
+        <meta property="og:type" content="website" />
+      </Head>
+      <noscript>
+        <StaticHero t={t} counts={STATIC_COUNTS} />
+      </noscript>
+      <BrowserOnly fallback={<StaticHero t={t} counts={STATIC_COUNTS} />}>
+        {() => <Inner t={t} />}
+      </BrowserOnly>
     </Layout>
   );
 }


### PR DESCRIPTION
## Summary
- a11y: 分页 / Notes / GPA 输入 / 奖徽章等加 `aria-label`；Notes 改为可点击对话框（保留 `title=` 回退），支持 Esc 关闭和焦点回归
- i18n: 引入 `COPY['zh-Hans' | 'en']` 字典 + `useDocusaurusContext().i18n.currentLocale`，全量翻译页面文案（含表头、筛选、空状态、错误提示）
- UX: 筛选状态双向同步 URL（`?school=&tier=&year=&result=&q=...`），挂载时从 URL 回填；新增 "复制分享链接" 按钮；空结果展示当前激活的筛选 + 显眼的 "清除全部" 按钮；视窗 < 768px 自动切换为卡片列表
- SEO: 引入 `<Head>` 注入 meta description / og:title / og:description；在 BrowserOnly fallback 与 `<noscript>` 中渲染静态 hero（含静态 counts fallback），让爬虫和无 JS 用户都能看到核心内容

## Test plan
- [x] `npm run build` — 通过（仅原有的 docs 链接 warning，与本 PR 无关）
- [x] `curl -sI http://localhost:3987/datapoints` → 200
- [x] `curl -sI 'http://localhost:3987/datapoints?school=Stanford'` → 200
- [x] 静态 HTML 包含 `og:title`、`og:description`、`<noscript>` hero
- [ ] 手动验证：切换 locale，所有文案随 locale 切换
- [ ] 手动验证：调整任一筛选，URL 实时更新；复制 URL 在新窗口打开，状态恢复
- [ ] 手动验证：筛选到 0 行时，空状态显示当前筛选 chips + Clear all 按钮
- [ ] 手动验证：浏览器宽度 < 768px 时显示卡片视图，桌面宽度显示表格
- [ ] 手动验证：键盘 Tab 顺序覆盖 搜索 → 筛选 → GPA → 清除/分享 → 表格 → 分页；Notes 按钮 Enter 可打开对话框，Esc 关闭