### PR TITLE
fix(datapoints): 页眉走 live /api/stats + 首屏不再闪空状态

### DIFF
--- a/src/lib/dp/api.js
+++ b/src/lib/dp/api.js
@@ -120,15 +120,23 @@ function buildUrl(path, params) {
   return url.toString();
 }
 
-// Also expose snapshot counts for the header. Always reads from the local
-// snapshot to avoid an extra round-trip (the API would need a /api/stats route).
+// Counts for the header. Prefer the live worker (/api/stats) so newly
+// submitted DPs are reflected; fall back to the frozen snapshot if the
+// worker is unreachable.
 export async function getCounts() {
   try {
-    const snap = await loadSnapshot();
-    return snap.counts;
+    const r = await fetch(`${DP_API_BASE}/api/stats`, { credentials: 'include' });
+    if (r.ok) return await r.json();
+    throw new Error(`HTTP ${r.status}`);
   } catch (err) {
-    warnDev('getCounts failed:', err && err.message ? err.message : err);
-    return { applicants: 0, programs: 0, datapoints: 0 };
+    warnDev('getCounts live fetch failed, falling back to snapshot:', err && err.message ? err.message : err);
+    try {
+      const snap = await loadSnapshot();
+      return snap.counts;
+    } catch (err2) {
+      warnDev('getCounts snapshot fallback failed:', err2 && err2.message ? err2.message : err2);
+      return { applicants: 0, programs: 0, datapoints: 0 };
+    }
   }
 }
 

--- a/src/pages/datapoints.jsx
+++ b/src/pages/datapoints.jsx
@@ -427,7 +427,9 @@ function Table({ counts, filterOpts, me, meChecked, t }) {
         {t.summaryMatched} <b>{totalCount}</b> {t.summaryRows} · {page + 1} / {totalPages} {t.summaryPage}
       </div>
 
-      {paged.length === 0 ? (
+      {loading && rows.length === 0 ? (
+        <div className={styles.loading}>{t.loadingData}</div>
+      ) : paged.length === 0 ? (
         <EmptyState t={t} activeFilters={activeFilters} />
       ) : isMobile ? (
         <MobileCards rows={paged} t={t} onCardClick={setOpenApplicantId} />


### PR DESCRIPTION
- getCounts() 改成 fetch /api/stats，snapshot 退化为兜底；解决页眉 1908 vs 匹配 1928 不一致。
- Table 首屏 rows 还没回来时显示 loading 占位，不再短暂渲染 EmptyState。

依赖 csgrad-backend 同步部署 /api/stats 端点；未部署时 getCounts 会 fallback 到 snapshot（仍是 1908），不会报错。