### PR TITLE
chore(submit-dp): 跟随后端 applicant 契约统一，POST 返回读 r.applicant

### DIFF
--- a/src/pages/submit-dp.jsx
+++ b/src/pages/submit-dp.jsx
@@ -554,7 +554,7 @@ function Inner() {
         setMsg({ type: 'ok', text: t.saved });
       } else {
         const r = await createMyApplicant(payload);
-        setApplicant(r.row);
+        setApplicant(r.applicant);
         setMsg({ type: 'ok', text: t.created });
       }
     } catch (e) {


### PR DESCRIPTION
## 概要

\`src/pages/submit-dp.jsx\` 的 \`saveApplicant()\` 在创建档案分支里读 \`r.row\`，但后端 PR 把 POST \`/api/applicant/me\` 返回 shape 从 \`{ row: <camelCase> }\` 改成 \`{ applicant: <snake_case> }\` 后，旧字段名就读不到了。这里把 \`setApplicant(r.row)\` 改成 \`setApplicant(r.applicant)\`。

## ⚠️ BREAKING CHANGE — 部署顺序

**必须等后端 PR merge + \`npx wrangler deploy\` 之后再 merge 本 PR**：
- 配对后端 PR：https://github.com/RedInn7/csgrad-backend/pull/9
- 后端没部署前，POST 还在返回旧 \`{ row }\` shape，本 PR 改完会 \`setApplicant(undefined)\`，UI state 丢失（更糟）。

## Test plan

- [x] \`npm run start -- --port 3500\` 编译成功，\`curl localhost:3500/\` → 200
- [ ] **集成验证**（后端 PR 部署后再做）：登录态下打开 /submit-dp，填一份新档案点保存，UI 不应丢失刚填的内容，应显示「已创建」toast 且 form 进入 update 模式（再次点保存走 PATCH 分支）