### PR TITLE
fix(i18n): tracker 列名英文翻译 match/target 互换 bug

### DIFF
--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -3,10 +3,10 @@
     "message": "Reach"
   },
   "tracker.column.match": {
-    "message": "Target"
+    "message": "Match"
   },
   "tracker.column.target": {
-    "message": "Match"
+    "message": "Target"
   },
   "tracker.column.safety": {
     "message": "Safety"


### PR DESCRIPTION
## Summary

- 修复 \`i18n/en/code.json\` 中 \`tracker.column.match\` 与 \`tracker.column.target\` 两个 key 的 value 被搞反：之前 match→\"Target\"、target→\"Match\"，英文用户看到的看板列名与列 id 语义不一致。
- 互换两者 value，恢复 match→\"Match\"、target→\"Target\"，与 \`src/pages/tracker.jsx\` 里的列 id 语义一致。

## Diff

```diff
   "tracker.column.match": {
-    "message": "Target"
+    "message": "Match"
   },
   "tracker.column.target": {
-    "message": "Match"
+    "message": "Target"
   },
```

## Test plan

纯 i18n JSON 翻译文件改动，本地 webpack/dev server compiled successfully。reviewer 手动验证：

- [ ] \`npm run start\` 起 dev server
- [ ] 切到英文版 tracker 页（URL 加 \`?language=en\` 或直接访问 \`/en/tracker\`）
- [ ] 看板四列从左到右应为：**Reach**、**Match**、**Target**、**Safety**（之前 bug 状态下第 2/3 列分别错显为 Target/Match）
- [ ] 编辑 modal 里 \"Category\" 下拉里四个选项的 title 部分（括号前那个词）与新列名一致