### PR TITLE
fix(datapoints): 立刻渲染壳，去掉全屏 Loading 阻塞

### DIFF
--- a/src/pages/datapoints.jsx
+++ b/src/pages/datapoints.jsx
@@ -12,6 +12,7 @@ const MOBILE_BREAKPOINT = 768;
 
 // Pre-hydration / no-JS fallback counts. Refresh when snapshot regenerates.
 const STATIC_COUNTS = { datapoints: 1908, applicants: 317, programs: 280 };
+const EMPTY_FILTER_OPTS = { schools: [], tiers: [], years: [], ugCats: [], majors: [] };
 
 const COPY = {
   'zh-Hans': {
@@ -233,8 +234,12 @@ function StaticHero({ t, counts }) {
 // ---------- Inner: data load orchestration ----------
 
 function Inner({ t }) {
-  const [counts, setCounts] = useState(null);
-  const [filterOpts, setFilterOpts] = useState(null);
+  // Render the page shell immediately with STATIC_COUNTS + empty filter
+  // dropdowns; counts/filterOpts populate async without blocking the UI.
+  // The Table mounts in parallel and starts fetching rows right away.
+  // Avoids a 500ms+ full-screen "Loading…" splash gating everything.
+  const [counts, setCounts] = useState(STATIC_COUNTS);
+  const [filterOpts, setFilterOpts] = useState(EMPTY_FILTER_OPTS);
   const [error, setError] = useState(null);
   const [me, setMe] = useState(null);
   const [meChecked, setMeChecked] = useState(false);
@@ -265,7 +270,6 @@ function Inner({ t }) {
   }, []);
 
   if (error) return <div className={styles.errorBox}>{t.loadFail}{error}</div>;
-  if (!counts || !filterOpts) return <div className={styles.loading}>{t.loadingData}</div>;
   return <Table counts={counts} filterOpts={filterOpts} me={me} meChecked={meChecked} t={t} />;
 }
 
@@ -345,9 +349,15 @@ function Table({ counts, filterOpts, me, meChecked, t }) {
   const [totalCount, setTotalCount] = useState(0);
   const [loading, setLoading] = useState(true);
   const [apiError, setApiError] = useState(null);
+  const firstFetchRef = useRef(true);
 
   useEffect(() => {
     let cancelled = false;
+    // First fetch fires immediately so the table appears as fast as possible;
+    // subsequent filter/page changes get a 250ms debounce to coalesce rapid
+    // dropdown clicks.
+    const delay = firstFetchRef.current ? 0 : 250;
+    firstFetchRef.current = false;
     const handle = setTimeout(async () => {
       setLoading(true);
       setApiError(null);
@@ -370,7 +380,7 @@ function Table({ counts, filterOpts, me, meChecked, t }) {
       } finally {
         if (!cancelled) setLoading(false);
       }
-    }, 250);
+    }, delay);
     return () => { cancelled = true; clearTimeout(handle); };
   }, [school, tier, year, result, ugCat, major, page]);
 


### PR DESCRIPTION
## 问题

点 /datapoints 会先看到一整片「加载 DataPoints…」卡顿，体验差。

## 根因

Inner 组件 gating 在 counts && filterOpts 都到位才渲染 \<Table\>：
\`\`\`
if (!counts || !filterOpts) return <div>Loading…</div>;
\`\`\`
而 Table 里首次 row fetch 又有 250ms debounce — 串行下来 1s+ 才有内容。

## 修复

- Inner 用 STATIC_COUNTS + 空 filterOpts 初始化，立刻渲染壳；async 更新到位后替换
- Table 加 firstFetchRef，首次 fetch delay=0；后续 filter/page 变化才 debounce 250ms

## 验证

启 dev server + curl /datapoints → 200 OK + 编译过。**reviewer 手动验**：刷新 /datapoints，应该看到头部 + 筛选器 + 表格容器立刻出现，表格里短暂显示 loading（rows 在飞）。不再有"加载 DataPoints…"全屏白屏。