### PR TITLE
feat(dp): Pub badge 加固定 legend 解释 P/S × 1/*

### DIFF
--- a/src/pages/datapoints.jsx
+++ b/src/pages/datapoints.jsx
@@ -64,6 +64,7 @@ const COPY = {
     pubPstar: '已发表 · 顶会合作者',
     pubS1: '在投 · 顶会一作',
     pubSstar: '在投 · 顶会合作者',
+    pubLegend: 'P=已发表 S=在投 ｜ 1=一作 *=合作者',
     notesTitle: '查看备注详情',
     notesDialog: '备注详情',
     closeDialog: '关闭',
@@ -153,6 +154,7 @@ const COPY = {
     pubPstar: 'Published · top venue, co-author',
     pubS1: 'Under submission · top venue, first author',
     pubSstar: 'Under submission · top venue, co-author',
+    pubLegend: 'P=Published S=Submission | 1=First author *=Co-author',
     notesTitle: 'View notes',
     notesDialog: 'Notes',
     closeDialog: 'Close',
@@ -536,7 +538,20 @@ function DesktopTable({ rows, t, onRowClick }) {
             <th scope="col">{t.thGpa}</th>
             <th scope="col">{t.thResearch}</th>
             <th scope="col">{t.thInternship}</th>
-            <th scope="col">{t.thPub}</th>
+            <th scope="col" title={t.pubLegend}>
+              <div>{t.thPub}</div>
+              <div
+                style={{
+                  fontSize: 11,
+                  fontWeight: 400,
+                  color: 'var(--ifm-color-emphasis-600)',
+                  marginTop: 2,
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {t.pubLegend}
+              </div>
+            </th>
             <th scope="col">{t.thNotes}</th>
           </tr>
         </thead>
@@ -764,8 +779,20 @@ function MobileCards({ rows, t, onCardClick }) {
             <span style={labelStyle}>{t.cardLabelInternship}</span>
             <span><CountInlineBadges domestic={a.internship_domestic_count} overseas={a.internship_overseas_count} t={t} /></span>
           </div>
-          <div style={row}>
-            <span style={labelStyle}>{t.cardLabelPub}</span>
+          <div style={{ ...row, alignItems: 'flex-start' }}>
+            <span style={labelStyle}>
+              {t.cardLabelPub}
+              <div
+                style={{
+                  fontSize: 11,
+                  color: 'var(--ifm-color-emphasis-500)',
+                  marginTop: 2,
+                  fontWeight: 400,
+                }}
+              >
+                {t.pubLegend}
+              </div>
+            </span>
             <span><PubBadges a={a} t={t} /></span>
           </div>
           <div style={{ ...row, alignItems: 'flex-start' }}>

--- a/src/pages/submit-dp.jsx
+++ b/src/pages/submit-dp.jsx
@@ -70,6 +70,7 @@ const COPY = {
     badgeFinal: '最终',
     progSearchLabel: '项目（搜学校或 program 名）',
     progSearchPlaceholder: '如 stanford mscs / CMU MIIS',
+    pubLegend: 'P=已发表 S=在投 ｜ 1=一作 *=合作者',
     groups: {
       edu: '教育背景',
       courses: '核心课程修读',
@@ -176,6 +177,7 @@ const COPY = {
     badgeFinal: 'Final',
     progSearchLabel: 'Program (search school or program name)',
     progSearchPlaceholder: 'e.g. stanford mscs / CMU MIIS',
+    pubLegend: 'P=Published S=Submission | 1=First author *=Co-author',
     groups: {
       edu: 'Education',
       courses: 'Core CS courses taken',
@@ -946,6 +948,15 @@ function ApplicantForm({ t, locale, form, setForm, setField, toggleArrayValue, h
         </Group>
 
         <Group id="section-pub" title={t.groups.pub}>
+          <div
+            style={{
+              fontSize: 11,
+              color: 'var(--ifm-color-emphasis-600)',
+              marginBottom: 8,
+            }}
+          >
+            {t.pubLegend}
+          </div>
           <Check id="pub_top_first_author" label={L.pub_top_first_author} value={form.pub_top_first_author} onChange={(v) => setField('pub_top_first_author', v)} />
           <Check id="pub_top_other_author" label={L.pub_top_other_author} value={form.pub_top_other_author} onChange={(v) => setField('pub_top_other_author', v)} />
           <Check id="submission_top_first_author" label={L.submission_top_first_author} value={form.submission_top_first_author} onChange={(v) => setField('submission_top_first_author', v)} />


### PR DESCRIPTION
datapoints 表格 Pub 列用 4 个 badge：P1/P*/S1/S*。新用户根本看不懂这套缩写（用户在 review 时也指出过），移动端没有 hover 完全 hidden。

不动 badge 文本本身（保留已有用户认知），加固定 legend 解释：

- COPY 双语加 \`pubLegend\` = \"P=已发表 S=在投 ｜ 1=一作 *=合作者\"
- datapoints.jsx Pub 表头加副标题 legend；MobileCards Pub 行 label 旁同样加 hint
- submit-dp.jsx Pub group 开头加同样 legend

## reviewer 手动验证
1. /datapoints 桌面端 → Pub 表头看到两行（粗体 Pub + 小字 legend）
2. /datapoints 手机宽度 → Pub 卡片行看到 hint
3. /submit-dp → "科研产出" group 开头看到 legend
4. 切英文版（locale=en）→ legend 用英文版