### PR TITLE
chore(ux): 补 3 个页面缺失的 Head meta + positioning 表单 focus

### DIFF
--- a/src/pages/school-positioning-result.jsx
+++ b/src/pages/school-positioning-result.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useRef } from 'react';
 import Layout from '@theme/Layout';
 import BrowserOnly from '@docusaurus/BrowserOnly';
+import Head from '@docusaurus/Head';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import { WORKER_BASE_URL } from '@site/src/lib/positioning/api';
 import styles from './school-positioning-result.module.css';
@@ -11,7 +12,7 @@ const MAX_POLLS = 20;
 const COPY = {
   'zh-Hans': {
     pageTitle: '选校定位结果',
-    pageDesc: '你的完整选校方案',
+    pageDesc: '选校定位结果：你的完整 MSCS 选校方案与档位匹配报告',
     backHome: '返回首页',
     backForm: '返回填写页',
     downloadPdf: '下载 PDF 报告',
@@ -42,7 +43,7 @@ const COPY = {
   },
   en: {
     pageTitle: 'Positioning Result',
-    pageDesc: 'Your full school plan',
+    pageDesc: 'Your school positioning result — full MSCS school list and tier-matched plan',
     backHome: 'Back to home',
     backForm: 'Back to form',
     downloadPdf: 'Download PDF',
@@ -408,11 +409,17 @@ function ResultBody() {
 }
 
 export default function SchoolPositioningResultPage() {
+  const { i18n } = useDocusaurusContext();
+  const locale = pickLocale(i18n.currentLocale);
+  const t = COPY[locale];
   return (
-    <Layout
-      title="MSCS Positioning Result"
-      description="Your full school list after positioning checkout"
-    >
+    <Layout title={t.pageTitle} description={t.pageDesc}>
+      <Head>
+        <meta name="description" content={t.pageDesc} />
+        <meta property="og:title" content={t.pageTitle} />
+        <meta property="og:description" content={t.pageDesc} />
+        <meta property="og:type" content="website" />
+      </Head>
       <BrowserOnly fallback={<div className={styles.pageWrapper} />}>
         {() => <ResultBody />}
       </BrowserOnly>

--- a/src/pages/school-positioning.jsx
+++ b/src/pages/school-positioning.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useMemo, useEffect } from 'react';
 import Layout from '@theme/Layout';
 import BrowserOnly from '@docusaurus/BrowserOnly';
+import Head from '@docusaurus/Head';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import { FIELD_DEFINITIONS } from '@site/src/lib/positioning/profile-schema';
 import { WORKER_BASE_URL } from '@site/src/lib/positioning/api';
@@ -10,7 +11,7 @@ import styles from './school-positioning.module.css';
 const COPY = {
   'zh-Hans': {
     pageTitle: 'MSCS 选校定位',
-    pageDesc: '基于你的背景，给出 csgrad tier 档位预估与完整选校方案',
+    pageDesc: '选校定位评估：基于你的背景，给出 csgrad tier 档位预估与完整选校方案',
     backHome: '返回首页',
     heroTitle: 'MSCS 选校定位',
     heroLead: '填写你的背景，立即生成 MSCS 档位预估与选校方向建议。',
@@ -37,7 +38,7 @@ const COPY = {
   },
   en: {
     pageTitle: 'MSCS School Positioning',
-    pageDesc: 'Tier estimation and full school list based on your profile',
+    pageDesc: 'Find the school tier that matches your background — tier estimation and full school list based on your profile',
     backHome: 'Back to home',
     heroTitle: 'MSCS School Positioning',
     heroLead: 'Fill in your profile to get an instant MSCS tier estimate and school direction suggestions.',
@@ -256,6 +257,11 @@ function FormBody() {
     setErrorMsg('');
     if (hasErrors) {
       setPreview(null);
+      const firstKey = Object.keys(errors)[0];
+      // Error keys are either "fieldKey" or "groupKey.subKey"; field ids use dashes.
+      const fieldId = `f-${firstKey.replace('.', '-')}`;
+      const el = document.getElementById(fieldId);
+      if (el) el.focus({ preventScroll: false });
       return;
     }
     try {
@@ -542,11 +548,17 @@ function FormBody() {
 }
 
 export default function SchoolPositioningPage() {
+  const { i18n } = useDocusaurusContext();
+  const locale = pickLocale(i18n.currentLocale);
+  const t = COPY[locale];
   return (
-    <Layout
-      title="MSCS School Positioning"
-      description="Paid MSCS school positioning based on csgrad tier classifier"
-    >
+    <Layout title={t.pageTitle} description={t.pageDesc}>
+      <Head>
+        <meta name="description" content={t.pageDesc} />
+        <meta property="og:title" content={t.pageTitle} />
+        <meta property="og:description" content={t.pageDesc} />
+        <meta property="og:type" content="website" />
+      </Head>
       <BrowserOnly fallback={<div className={styles.pageWrapper} />}>
         {() => <FormBody />}
       </BrowserOnly>

--- a/src/pages/tracker.jsx
+++ b/src/pages/tracker.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import Layout from '@theme/Layout';
+import Head from '@docusaurus/Head';
 import Translate, { translate } from '@docusaurus/Translate';
 import {
   DndContext,
@@ -798,11 +799,20 @@ export default function TrackerPage() {
 
   const totalCards = cards.length;
 
+  const pageTitle = translate({ id: 'tracker.page.title', message: '申请进度追踪器' });
+  const pageDesc = translate({
+    id: 'tracker.page.description',
+    message: '申请进度追踪：管理研究生申请的轮次、推荐信、文书与截止日期',
+  });
+
   return (
-    <Layout
-      title={translate({ id: 'tracker.page.title', message: '申请进度追踪器' })}
-      description={translate({ id: 'tracker.page.description', message: '管理你的研究生申请进度' })}
-    >
+    <Layout title={pageTitle} description={pageDesc}>
+      <Head>
+        <meta name="description" content={pageDesc} />
+        <meta property="og:title" content={pageTitle} />
+        <meta property="og:description" content={pageDesc} />
+        <meta property="og:type" content="website" />
+      </Head>
       <div className={styles.pageWrapper}>
         {/* Top bar */}
         <div className={styles.topBar}>


### PR DESCRIPTION
## Summary
- school-positioning / school-positioning-result / tracker 3 个页面之前没有 `<Head>`，影响 SEO 和分享卡片。现在加上 `meta name=description` + `og:title` / `og:description` / `og:type`，和 datapoints.jsx 保持一致。
- school-positioning 表单 submit 校验失败时只 return，无障碍体验差。现在 focus 第一个错误字段：顶级字段用 `f-{key}`，group 子字段用 `f-{group}-{sub}`（dot→dash 映射 errors key）。
- 三个页面的 pageDesc 文案改得更具描述性（中英都更新），Layout title 也改为读 COPY，i18n 一致。

## Test plan
- [x] dev server 编译通过（compiled successfully in 6.67s）
- [x] curl 三个页面均 200：`/school-positioning`、`/school-positioning-result`、`/tracker`
- [ ] UI 验：浏览器开发者工具检查 `<head>` 里 description / og:tags 已注入
- [ ] UI 验：打开 `/school-positioning` 不填任何字段直接点 "生成档位预估"，应自动 focus 第一个红框字段
- [ ] UI 验：填几个字段、留 group 子字段空（如 jointForeignSchool），submit 应 focus 到该子字段（id=`f-{group}-{sub}`）
- [ ] 分享时复制 URL 到 Slack/微信，看预览卡片是否带新 description