### PR TITLE
chore(storage): 集中管理 localStorage key

### DIFF
--- a/src/lib/storage-keys.js
+++ b/src/lib/storage-keys.js
@@ -1,0 +1,6 @@
+// Centralized localStorage / sessionStorage key registry.
+// Keep keys here so a rename / data migration can be done in one place.
+export const STORAGE_KEYS = {
+  applicantDraft: 'dp_applicant_draft',
+  trackerData: 'csgrad_tracker_data',
+};

--- a/src/pages/submit-dp.jsx
+++ b/src/pages/submit-dp.jsx
@@ -18,6 +18,7 @@ import {
 } from '@site/src/lib/dp/enums';
 import SignInButtons from '@site/src/lib/auth/SignInButtons';
 import { startOAuth } from '@site/src/lib/auth/oauth';
+import { STORAGE_KEYS } from '../lib/storage-keys';
 import styles from './submit-dp.module.css';
 
 // ---------- i18n ----------
@@ -482,11 +483,11 @@ function Inner() {
           if (r.applicant) setForm(applicantToForm(r.applicant));
           // Restore draft saved before OAuth redirect (if any).
           try {
-            const draft = localStorage.getItem('dp_applicant_draft');
+            const draft = localStorage.getItem(STORAGE_KEYS.applicantDraft);
             if (draft && !r.applicant) {
               setForm((prev) => ({ ...prev, ...JSON.parse(draft) }));
             }
-            localStorage.removeItem('dp_applicant_draft');
+            localStorage.removeItem(STORAGE_KEYS.applicantDraft);
           } catch {}
         } catch (e) {
           // ignore: 401 happens when getMyApplicant is called pre-auth in some race
@@ -507,7 +508,7 @@ function Inner() {
     setSignInError(null);
     try {
       await startOAuth(provider, {
-        draftKey: 'dp_applicant_draft',
+        draftKey: STORAGE_KEYS.applicantDraft,
         draftValue: form,
       });
     } catch (e) {

--- a/src/pages/tracker.jsx
+++ b/src/pages/tracker.jsx
@@ -18,10 +18,8 @@ import {
   arrayMove,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
+import { STORAGE_KEYS } from '../lib/storage-keys';
 import styles from './tracker.module.css';
-
-// ============ Constants ============
-const STORAGE_KEY = 'csgrad_tracker_data';
 
 function getColumns() {
   return [
@@ -592,7 +590,7 @@ export default function TrackerPage() {
   // Load from localStorage
   useEffect(() => {
     try {
-      const saved = localStorage.getItem(STORAGE_KEY);
+      const saved = localStorage.getItem(STORAGE_KEYS.trackerData);
       if (saved) {
         const parsed = JSON.parse(saved);
         if (Array.isArray(parsed)) setCards(parsed);
@@ -605,7 +603,7 @@ export default function TrackerPage() {
   // Save to localStorage
   useEffect(() => {
     try {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(cards));
+      localStorage.setItem(STORAGE_KEYS.trackerData, JSON.stringify(cards));
     } catch (e) {
       // ignore
     }


### PR DESCRIPTION
## Summary
- 新增 `src/lib/storage-keys.js` 作为 localStorage key 注册表，集中两个现有 key：`dp_applicant_draft` / `csgrad_tracker_data`
- `src/pages/submit-dp.jsx`：3 处 `'dp_applicant_draft'` magic string 替换为 `STORAGE_KEYS.applicantDraft`
- `src/pages/tracker.jsx`：删除本地 `STORAGE_KEY` 常量，改用 `STORAGE_KEYS.trackerData`

字符串值未改动，现有用户的草稿与 tracker 数据不受影响。后续 rename / 数据迁移在 registry 单点改即可。

## Test plan
- [x] `npm run start -- --port 3508` 编译通过（import 路径正确）
- [x] `curl /submit-dp` 200
- [x] `curl /tracker` 200
- [ ] 手测：草稿在 OAuth 跳转后恢复正常；tracker 卡片持久化正常