### PR TITLE
feat(dp): getFilterOptions 优先走 live /api/filter-options，失败 fallback 到 snapshot

### DIFF
--- a/src/lib/dp/api.js
+++ b/src/lib/dp/api.js
@@ -90,14 +90,34 @@ const TIER_ORDER = ['SSS', 'SS', 'S', 'A', 'B', 'C', 'D'];
 
 /**
  * Returns the filter-option lists used by the DataPoints page filters.
- * Reads the slim snapshot (~2KB) and reorders tiers by the canonical order.
+ * Prefers the live worker (/api/filter-options) so newly submitted DPs'
+ * schools / majors / years show up in the dropdowns; falls back to the
+ * frozen snapshot if the worker is unreachable.
  * @returns {Promise<{schools: string[], tiers: string[], years: number[], ugCats: string[], majors: string[]}>}
  */
 export async function getFilterOptions() {
-  const snap = await loadSnapshot();
-  const opts = snap.options || {};
+  try {
+    const r = await fetch(`${DP_API_BASE}/api/filter-options`, { credentials: 'include' });
+    if (r.ok) {
+      const opts = await r.json();
+      return reorderTiers(opts);
+    }
+    throw new Error(`HTTP ${r.status}`);
+  } catch (err) {
+    warnDev('getFilterOptions live fetch failed, falling back to snapshot:', err && err.message ? err.message : err);
+    try {
+      const snap = await loadSnapshot();
+      return reorderTiers(snap.options || {});
+    } catch (err2) {
+      warnDev('getFilterOptions snapshot fallback failed:', err2 && err2.message ? err2.message : err2);
+      return { schools: [], tiers: [], years: [], ugCats: [], majors: [] };
+    }
+  }
+}
+
+// Reorder tiers by canonical rank, append non-canonical at the end.
+function reorderTiers(opts) {
   const tiers = opts.tiers || [];
-  // Reorder by canonical tier rank, append non-canonical at the end.
   const tierList = TIER_ORDER.filter((t) => tiers.includes(t));
   for (const t of tiers) if (!TIER_ORDER.includes(t)) tierList.push(t);
   return {

--- a/src/lib/dp/api.js
+++ b/src/lib/dp/api.js
@@ -115,9 +115,9 @@ export async function getFilterOptions() {
   }
 }
 
-// Reorder tiers by canonical rank, append non-canonical at the end.
 function reorderTiers(opts) {
   const tiers = opts.tiers || [];
+  // Reorder by canonical tier rank, append non-canonical at the end.
   const tierList = TIER_ORDER.filter((t) => tiers.includes(t));
   for (const t of tiers) if (!TIER_ORDER.includes(t)) tierList.push(t);
   return {


### PR DESCRIPTION
## Summary
- \`getFilterOptions()\` 改为先 fetch \`/api/filter-options\`，失败再 fallback 到 \`dp-snapshot.json\`（仿 \`getCounts\` 模式）
- 抽出 \`reorderTiers()\` 复用 \`TIER_ORDER\` 排序逻辑

## Why
\`dp-snapshot.json\` 的 \`options\` 是迁移时一次性生成的，新提交的 DP 用了 snapshot 没的学校 / 专业 / 年份就进不了下拉。改 live 后新 DP 立刻能被筛到。

## 部署顺序（重要）

> **本 PR 必须等后端 PR merge + 部署完成后再 merge**
>
> 1. 后端 PR \`RedInn7/csgrad-backend\` 上的 \`chore/ux-audit-unit-11-backend-filter-options\` merge
> 2. \`cd cloudflare-worker && npx wrangler deploy\`
> 3. **本 PR merge**
>
> 后端未部署时本 PR 也能跑：\`getFilterOptions\` 会 fallback 到 snapshot，不会崩，只是看不到新 DP 的选项（即回退到 PR 之前的行为）。

## Test plan
- [x] \`npm run start -- --port 3510\`，\`curl /datapoints\` 返回 200
- [ ] 后端部署后访问 /datapoints，新 DP 的学校 / 专业 / 年份出现在筛选器下拉中
- [ ] 后端临时下线时（或网络断开）筛选器 fallback 到 snapshot，页面不崩