### PR TITLE
chore(ux): navbar 加"我的 DataPoints" + submit-dp/my-dp 头部互链回 /datapoints

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -106,6 +106,11 @@ const config = {
             label: '申请跟踪',
           },
           {
+            to: '/my-dp',
+            position: 'left',
+            label: '我的 DataPoints',
+          },
+          {
             href: 'https://github.com/csms-apply/csgrad',
             label: 'GitHub',
             position: 'right',

--- a/i18n/en/docusaurus-theme-classic/navbar.json
+++ b/i18n/en/docusaurus-theme-classic/navbar.json
@@ -26,5 +26,9 @@
   "item.label.选校定位": {
     "message": "Positioning",
     "description": "Navbar item with label 选校定位"
+  },
+  "item.label.我的 DataPoints": {
+    "message": "My DataPoints",
+    "description": "Navbar item with label 我的 DataPoints"
   }
 }

--- a/src/pages/my-dp.jsx
+++ b/src/pages/my-dp.jsx
@@ -16,6 +16,7 @@ const COPY = {
   'zh-Hans': {
     pageTitle: '我的 DataPoints',
     pageDesc: '管理你提交过的 csgrad DataPoints：查看、编辑、删除你的申请结果记录。',
+    browseAll: '← 浏览所有 DataPoints',
     loading: '加载中…',
     needSignIn: '需要登录',
     signInTip: '登录后才能查看你自己提交过的 DataPoints。',
@@ -72,6 +73,7 @@ const COPY = {
   en: {
     pageTitle: 'My DataPoints',
     pageDesc: 'Manage the csgrad DataPoints you have submitted: view, edit, and delete your application result records.',
+    browseAll: '← Browse all DataPoints',
     loading: 'Loading…',
     needSignIn: 'Sign in required',
     signInTip: 'You need to sign in to view DataPoints you have submitted.',
@@ -675,7 +677,10 @@ function Inner({ t }) {
     <div className={styles.wrap}>
       <header className={styles.header}>
         <div className={styles.headerTop}>
-          <h1>{t.heading}</h1>
+          <div>
+            <h1>{t.heading}</h1>
+            <a href="/datapoints" className={styles.backLink}>{t.browseAll}</a>
+          </div>
           <div className={styles.headerRight}>
             <span className={styles.meBadge}>👤 {me.nickname}{me.role === 'admin' ? t.adminTag : ''}</span>
             <button className={styles.linkBtn} onClick={handleSignOut}>{t.signOut}</button>

--- a/src/pages/my-dp.module.css
+++ b/src/pages/my-dp.module.css
@@ -36,6 +36,13 @@
   flex-wrap: wrap;
 }
 .headerRight { display: flex; align-items: center; gap: 8px; }
+.backLink {
+  display: inline-block;
+  font-size: 13px;
+  color: var(--ifm-color-emphasis-700);
+  text-decoration: none;
+}
+.backLink:hover { text-decoration: underline; }
 .lead { color: var(--ifm-color-emphasis-700); font-size: 14px; margin: 0 0 12px; }
 .notice {
   padding: 10px 14px;

--- a/src/pages/submit-dp.jsx
+++ b/src/pages/submit-dp.jsx
@@ -26,6 +26,7 @@ const COPY = {
   'zh-Hans': {
     pageTitle: '提交 DataPoints',
     pageDesc: 'csgrad DataPoints 提交：先填申请者背景档案，再提交录取数据点。',
+    browseAll: '← 浏览所有 DataPoints',
     loading: '加载中…',
     needSignIn: '需要登录',
     signInLead: '用 Google 或 GitHub 登录后才能提交 DataPoints。',
@@ -133,6 +134,7 @@ const COPY = {
   en: {
     pageTitle: 'Submit DataPoints',
     pageDesc: 'csgrad DataPoints submission: fill out your applicant profile, then submit each admission data point.',
+    browseAll: '← Browse all DataPoints',
     loading: 'Loading…',
     needSignIn: 'Sign in required',
     signInLead: 'Sign in with Google or GitHub to submit DataPoints.',
@@ -582,7 +584,10 @@ function Inner() {
     <div className={styles.wrap}>
       <header className={styles.header}>
         <div className={styles.headerTop}>
-          <h1>{t.pageTitle}</h1>
+          <div>
+            <h1>{t.pageTitle}</h1>
+            <a href="/datapoints" className={styles.backLink}>{t.browseAll}</a>
+          </div>
           {me ? (
             <span className={styles.meBadge}>
               {t.youAre} {me.nickname}{me.role === 'admin' ? ` · ${t.adminTag}` : ''}

--- a/src/pages/submit-dp.module.css
+++ b/src/pages/submit-dp.module.css
@@ -45,6 +45,13 @@
   gap: 12px;
   flex-wrap: wrap;
 }
+.backLink {
+  display: inline-block;
+  font-size: 13px;
+  color: var(--ifm-color-emphasis-700);
+  text-decoration: none;
+}
+.backLink:hover { text-decoration: underline; }
 .lead { color: var(--ifm-color-emphasis-700); font-size: 14px; margin: 0 0 8px; line-height: 1.6; }
 .meBadge {
   padding: 4px 10px;


### PR DESCRIPTION
## Summary
- navbar 新增 "我的 DataPoints" / "My DataPoints" 入口，链接到 `/my-dp`。i18n 沿用现有 `item.label.<label>` 模式，EN 翻译写在 `i18n/en/docusaurus-theme-classic/navbar.json`。
- `submit-dp.jsx` 和 `my-dp.jsx` 的 header 加 "← 浏览所有 DataPoints / ← Browse all DataPoints" 回链到 `/datapoints`，让用户在三页之间双向跳转更顺畅。
- 配套 `.backLink` CSS 模块样式（13px、emphasis-700、hover 下划线），不引入新组件，纯 `<a>`。

## 设计 / 实现要点
- navbar 顺序：项目介绍 / DataPoints / 选校定位 / 申请跟踪 / **我的 DataPoints** / GitHub / locale。把"我的 DataPoints"放在"申请跟踪"后、GitHub 前，左侧 group 内的逻辑流是"看 → 提交跟踪 → 管理自己的"。
- header 布局复用原有 `headerTop` flex（space-between），把 h1 + 回链包一层 div 作为左侧 flex child，右侧仍是 meBadge / SignInButtons / 登出按钮，space-between 行为不破。
- 之前已有的反向链：`submit-dp` 表单底部有"查看我提交过的 DP →"链到 `/my-dp`；`my-dp` 列表上方有"提交新的 DP →"链到 `/submit-dp`。这次的 `/datapoints` 回链补齐了三页之间剩下的两条边。

## Test plan
- [x] `npm run start -- --port 3509`，等编译完成，curl `/`、`/submit-dp`、`/my-dp`、`/datapoints` 都 200 OK
- [x] `.docusaurus/docusaurus.config.mjs` 生成的 navbar items 包含新增项（`to: /my-dp`, `label: 我的 DataPoints`）
- [ ] 人工验：浏览器点 navbar "我的 DataPoints" → 跳 `/my-dp`
- [ ] 人工验：`/submit-dp` 头部点 "← 浏览所有 DataPoints" → 跳 `/datapoints`
- [ ] 人工验：`/my-dp` 头部点 "← 浏览所有 DataPoints" → 跳 `/datapoints`
- [ ] 人工验：移动端 navbar 折叠菜单中新条目可见且可点
- [ ] 人工验：EN locale 下 navbar 显示 "My DataPoints"、两个回链显示 "← Browse all DataPoints"