### PR TITLE
chore(navbar): 去掉「我的 DataPoints」入口

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -106,11 +106,6 @@ const config = {
             label: '申请跟踪',
           },
           {
-            to: '/my-dp',
-            position: 'left',
-            label: '我的 DataPoints',
-          },
-          {
             href: 'https://github.com/csms-apply/csgrad',
             label: 'GitHub',
             position: 'right',

--- a/i18n/en/docusaurus-theme-classic/navbar.json
+++ b/i18n/en/docusaurus-theme-classic/navbar.json
@@ -26,9 +26,5 @@
   "item.label.选校定位": {
     "message": "Positioning",
     "description": "Navbar item with label 选校定位"
-  },
-  "item.label.我的 DataPoints": {
-    "message": "My DataPoints",
-    "description": "Navbar item with label 我的 DataPoints"
   }
 }


### PR DESCRIPTION
放在「申请跟踪」旁边显得很突兀，从 submit-dp / my-dp / datapoints 页内部互链就够了。