### PR TITLE
fix(datapoints): 备注单元格整格可点击

### DIFF
--- a/src/pages/datapoints.jsx
+++ b/src/pages/datapoints.jsx
@@ -944,7 +944,9 @@ function NotesCell({ d, a, t }) {
     };
   }, [open]);
 
-  if (parts.length === 0) return <span className={styles.muted}>—</span>;
+  if (parts.length === 0) {
+    return <span className={`${styles.muted} ${styles.notesEmpty}`}>—</span>;
+  }
   const fullText = parts.map(([label, text]) => `[${label}] ${text}`).join('\n\n');
   const preview = parts[0][1].slice(0, 60) + (parts[0][1].length > 60 || parts.length > 1 ? '…' : '');
 
@@ -959,11 +961,8 @@ function NotesCell({ d, a, t }) {
         style={{
           background: 'transparent',
           border: 0,
-          padding: 0,
           font: 'inherit',
           color: 'inherit',
-          cursor: 'pointer',
-          textAlign: 'left',
         }}
         className={styles.notesPreview}
       >

--- a/src/pages/datapoints.module.css
+++ b/src/pages/datapoints.module.css
@@ -175,14 +175,27 @@
 .pubOutlined     { background: transparent; color: var(--dp-pub-outlined-fg); border: 1px solid var(--dp-pub-outlined-border); padding: 1px 5px; }
 .pubOutlinedAlt  { background: transparent; color: var(--dp-pub-outlined-alt-fg); border: 1px solid var(--dp-pub-outlined-alt-border); padding: 1px 5px; }
 
-.notesCell { max-width: 280px; min-width: 180px; }
+.notesCell {
+  max-width: 280px;
+  min-width: 180px;
+  /* Drop cell padding so the inner button can fill the entire cell area —
+     clicking anywhere in the cell (not just on the text) opens the dialog. */
+  padding: 0 !important;
+}
 .notesPreview {
+  display: block;
+  width: 100%;
+  /* Mirror .table td default padding so visually nothing changes. */
+  padding: 14px;
   font-size: 12px;
   color: var(--ifm-color-emphasis-700);
   line-height: 1.5;
-  cursor: help;
-  display: inline-block;
-  max-width: 280px;
+  cursor: pointer;
+  text-align: left;
+}
+.notesEmpty {
+  display: block;
+  padding: 14px;
 }
 .moreNotes {
   margin-left: 4px;


### PR DESCRIPTION
之前 .notesPreview inline-block，点 cell 留白没反应，必须刚好点到文字。现在 td padding 移到 button 内部，button display:block + width:100% 撑满整个 cell — 任意位置点都能开 dialog。视觉无变化。