### PR TITLE
feat(result): 结果页展示 LLM 个性化建议段 + 优先用 personalizedReason

### DIFF
--- a/src/pages/school-positioning-result.jsx
+++ b/src/pages/school-positioning-result.jsx
@@ -24,6 +24,11 @@ const COPY = {
     phdSectionSub: 'PhD-friendly Programs',
     codingSectionTitle: '转码专项推荐',
     codingSectionSub: 'Transition-friendly programs',
+    adviceTitle: '🎯 针对你个人的整体建议',
+    adviceStrengths: '✨ 你的强项',
+    adviceWeaknesses: '⚠️ 你的短板与补救',
+    adviceStrategy: '🧭 申请策略',
+    adviceActionPlan: '📅 接下来 3-6 个月行动清单',
     bucketReach: '冲刺',
     bucketReachSub: 'Reach',
     bucketMatch: '匹配',
@@ -55,6 +60,11 @@ const COPY = {
     phdSectionSub: 'PhD-friendly programs',
     codingSectionTitle: 'Coding transition recommendations',
     codingSectionSub: 'Transition-friendly programs',
+    adviceTitle: '🎯 Personalized advice for you',
+    adviceStrengths: '✨ Your strengths',
+    adviceWeaknesses: '⚠️ Weak spots & how to compensate',
+    adviceStrategy: '🧭 Application strategy',
+    adviceActionPlan: '📅 Action plan for the next 3-6 months',
     bucketReach: 'Reach',
     bucketReachSub: 'Reach',
     bucketMatch: 'Match',
@@ -87,7 +97,9 @@ function getLabel(node, locale) {
 function SchoolCard({ school, locale, t }) {
   const name = getLabel(school.school || school.name, locale);
   const program = getLabel(school.program, locale);
-  const reason = getLabel(school.reason, locale);
+  const personalized = getLabel(school.personalizedReason, locale);
+  const fallbackReason = getLabel(school.reason, locale);
+  const reason = personalized || fallbackReason;
   const rawHref = school.doc || school.slug || school.url || school.link;
   const href = rawHref ? encodeURI(rawHref) : null;
   return (
@@ -100,6 +112,30 @@ function SchoolCard({ school, locale, t }) {
           {t.viewDetail} &rarr;
         </a>
       )}
+    </div>
+  );
+}
+
+function AdviceSection({ advice, t }) {
+  if (!advice) return null;
+  const items = [
+    { key: 'strengths', label: t.adviceStrengths, body: advice.strengths },
+    { key: 'weaknesses', label: t.adviceWeaknesses, body: advice.weaknesses },
+    { key: 'strategy', label: t.adviceStrategy, body: advice.strategy },
+    { key: 'actionPlan', label: t.adviceActionPlan, body: advice.actionPlan },
+  ].filter((it) => typeof it.body === 'string' && it.body.trim().length > 0);
+  if (items.length === 0) return null;
+  return (
+    <div className={styles.adviceCard}>
+      <p className={styles.adviceTitle}>{t.adviceTitle}</p>
+      <div className={styles.adviceList}>
+        {items.map((it) => (
+          <div key={it.key} className={styles.adviceItem}>
+            <div className={styles.adviceLabel}>{it.label}</div>
+            <div className={styles.adviceBody}>{it.body}</div>
+          </div>
+        ))}
+      </div>
     </div>
   );
 }
@@ -280,6 +316,7 @@ function ResultBody() {
               <h1 className={styles.tierName}>{tierName}</h1>
               {summary && <p className={styles.summary}>{summary}</p>}
             </div>
+            <AdviceSection advice={data.llmAdvice} t={t} />
             {Array.isArray(data.warnings) && data.warnings.length > 0 && (
               <div className={styles.warningList}>
                 {data.warnings.map((w, i) => (

--- a/src/pages/school-positioning-result.module.css
+++ b/src/pages/school-positioning-result.module.css
@@ -208,6 +208,71 @@
   gap: 10px;
 }
 
+.adviceCard {
+  background: linear-gradient(135deg, #fdf8ee 0%, #f7eed8 100%);
+  border: 1px solid #e6d4a8;
+  border-radius: 14px;
+  padding: 22px 24px;
+  margin: 0 0 20px;
+}
+
+[data-theme='dark'] .adviceCard {
+  background: linear-gradient(135deg, rgba(201, 169, 110, 0.15) 0%, rgba(201, 169, 110, 0.06) 100%);
+  border-color: rgba(201, 169, 110, 0.3);
+}
+
+.adviceTitle {
+  font-size: 1rem;
+  font-weight: 800;
+  color: #4a3a2a;
+  margin: 0 0 16px;
+  letter-spacing: 0.01em;
+}
+
+[data-theme='dark'] .adviceTitle {
+  color: #e8ddd0;
+}
+
+.adviceList {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.adviceItem {
+  padding: 12px 14px;
+  background: rgba(255, 255, 255, 0.55);
+  border-radius: 10px;
+  border-left: 3px solid #c9a96e;
+}
+
+[data-theme='dark'] .adviceItem {
+  background: rgba(0, 0, 0, 0.2);
+  border-left-color: rgba(201, 169, 110, 0.6);
+}
+
+.adviceLabel {
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: #4a3a2a;
+  margin-bottom: 6px;
+}
+
+[data-theme='dark'] .adviceLabel {
+  color: #e8ddd0;
+}
+
+.adviceBody {
+  font-size: 0.9rem;
+  color: #5a4a3a;
+  line-height: 1.75;
+  white-space: pre-wrap;
+}
+
+[data-theme='dark'] .adviceBody {
+  color: #c8b8a8;
+}
+
 .warningList {
   margin: 0 0 20px;
   display: flex;


### PR DESCRIPTION
## Summary
配套后端 PR (csgrad-backend#12) 的前端改动。

- `SchoolCard` 优先读 `school.personalizedReason`（LLM 改写过的"为什么适合你"），无则 fallback 到 `school.reason`
- 新增 `AdviceSection` 组件渲染 `data.llmAdvice` 的 4 段：strengths / weaknesses / strategy / actionPlan
- 配套 `.adviceCard` 等 CSS，沿用金色+奶油色风格 + 暗色模式
- 中英双语 COPY 同步加 5 个 advice 相关 key

**降级行为**：如果后端没返回 `llmAdvice`（LLM 失败、未启用 API key、旧 KV 记录），整段 advice section 不渲染，页面外观与现在完全一致。

PDF 导出会自动包含 advice（`html2pdf` 渲染整个 reportRef 节点）。

## Test plan
- [x] JSX 语法 OK
- [ ] 后端 PR 部署 + 设上 ANTHROPIC_API_KEY 之后，dev server 跑这个页面 → 完整方案显示 advice section + personalized reasons
- [ ] 后端没设 ANTHROPIC_API_KEY 的情况下打开 → 页面正常显示规则版理由，无 advice section
- [ ] 切英文，advice section 渲染英文版 label
- [ ] 暗色模式视觉无异常
- [ ] 下载 PDF → 确认 advice section 在 PDF 里