### PR TITLE
fix(dp): 本科类别移除"陆本"——提交不再可选、筛选下拉隐藏

### DIFF
--- a/src/lib/dp/api.js
+++ b/src/lib/dp/api.js
@@ -118,6 +118,13 @@ export async function getFilterOptions() {
   }
 }
 
+// UG-category values hidden from the filter dropdown. '陆本' (generic
+// "Mainland CN, other") was retired in favor of the more specific tiers
+// (清北/华五/985/211/双非...). We still render its label for historical rows,
+// but it no longer appears as a filter option. Applied here so both the live
+// worker response and the snapshot fallback are covered.
+const HIDDEN_UG_CATS = new Set(['陆本']);
+
 function reorderTiers(opts) {
   const tiers = opts.tiers || [];
   // Reorder by canonical tier rank, append non-canonical at the end.
@@ -127,7 +134,7 @@ function reorderTiers(opts) {
     schools: opts.schools || [],
     tiers: tierList,
     years: opts.years || [],
-    ugCats: opts.ugCats || [],
+    ugCats: (opts.ugCats || []).filter((c) => !HIDDEN_UG_CATS.has(c)),
     majors: opts.majors || [],
   };
 }

--- a/src/lib/dp/enums.js
+++ b/src/lib/dp/enums.js
@@ -1,10 +1,14 @@
 // Enum values for applicant + DP form fields. Mirrors the Seatable schema
 // so historical data renders consistently in the new form.
 
+// Selectable undergrad-school categories on the submit form.
+// Note: '陆本' (generic "Mainland CN, other") was retired here so it can no
+// longer be picked; its display label is kept in the page enum map so older
+// rows already tagged '陆本' still render correctly.
 export const UG_CATEGORIES = [
   '中外合办校（XJTLU等）', '陆本中外合办院系（JI/ZJUI等）',
   '清北', '华五', '国科/上科/南科', '10043', '985', '211',
-  '双非', '陆本', '美本', '加本', '英本', '澳本', '港本', '坡本', '欧陆本', '海本',
+  '双非', '美本', '加本', '英本', '澳本', '港本', '坡本', '欧陆本', '海本',
 ];
 
 export const UG_MAJORS = [


### PR DESCRIPTION
## 背景
datapoints 页面本科类别筛选项与提交表单里有一个泛用的 `陆本`(Mainland CN, other)，与更细的 `清北/华五/985/211/双非` 等档位重复且语义模糊。按需求移除。

## 改动
- **enums.js** `UG_CATEGORIES`：删除独立 `陆本`，提交表单以后不能再选；`陆本中外合办院系（JI/ZJUI等）` 是不同类别，保持不动。
- **api.js** `getFilterOptions`→`reorderTiers`：运行时从 `ugCats` 过滤掉 `陆本`，**live worker** 与 **snapshot fallback** 两条路都覆盖（worker 源码不在本仓库，故在前端后处理）。

## 兼容
历史已标 `陆本` 的数据保持原样：
- 显示标签（submit-dp.jsx 的 enum map）保留
- 徽章配色（datapoints.jsx `ugCatBadgeClass`）保留

## 验证
`npm run build` ✅ SUCCESS（仅有的 broken-link 警告来自 `转码项目.md`，与本次改动无关）。