### PR TITLE
Fix silent DataPoint migration loss

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
-    "sync-translations": "node --input-type=module scripts/sync-translations.js"
+    "sync-translations": "node --input-type=module scripts/sync-translations.js",
+    "test:migration": "node --test scripts/migration-integrity.test.mjs"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/scripts/d1-schema/README.md
+++ b/scripts/d1-schema/README.md
@@ -53,7 +53,19 @@ wrangler d1 execute DB_CSGRAD --file=tmp/003-datapoints.sql --remote
 
 ## Verification (local)
 
-This repo ships a local-sqlite end-to-end check:
+Generate the SQL first. Migration is fail-closed: any DataPoint without both
+required links is written to `manual-review.json`, then the command exits
+non-zero. Do not load its SQL into D1 until those links are repaired.
+
+```bash
+node scripts/migrate-seatable-to-d1.mjs
+
+# Diagnostic escape hatch only. The summary is marked INCOMPLETE/OVERRIDDEN.
+node scripts/migrate-seatable-to-d1.mjs --allow-skips
+```
+
+This repo ships a local-sqlite end-to-end check. It reads source/emitted counts
+from `manual-review.json` instead of accepting a hard-coded truncated count:
 
 ```bash
 node scripts/d1-schema/verify-local.mjs
@@ -61,6 +73,9 @@ node scripts/d1-schema/verify-local.mjs
 # 2. applies 0001_init.sql
 # 3. applies the three INSERT SQL files from scripts/migration-output/
 # 4. runs row-count + sample-join assertions
+
+# Verify an intentionally incomplete diagnostic artifact only:
+node scripts/d1-schema/verify-local.mjs --allow-skips
 ```
 
 ## Schema invariants

--- a/scripts/d1-schema/README.md
+++ b/scripts/d1-schema/README.md
@@ -53,9 +53,11 @@ wrangler d1 execute DB_CSGRAD --file=tmp/003-datapoints.sql --remote
 
 ## Verification (local)
 
-Generate the SQL first. Migration is fail-closed: any DataPoint without both
-required links is written to `manual-review.json`, then the command exits
-non-zero. Do not load its SQL into D1 until those links are repaired.
+Generate the SQL first. Migration is fail-closed: source-count mismatches,
+DataPoints without both required links, and blocking manual-review queues are
+written to `manual-review.json`, then the command exits non-zero. Deterministic
+duplicate-program merges are informational, not blocking. Do not load the SQL
+into D1 until the blocking items are repaired.
 
 ```bash
 node scripts/migrate-seatable-to-d1.mjs

--- a/scripts/d1-schema/verify-local.mjs
+++ b/scripts/d1-schema/verify-local.mjs
@@ -40,10 +40,14 @@ if (!migrationCounts) {
 }
 const integrity = assessMigrationIntegrity({
   sourceDatapoints: migrationCounts.source_datapoints,
+  expectedDatapoints: review.expected_counts.datapoints,
   emittedDatapoints: migrationCounts.emitted_datapoints,
   orphanNoApplicant: review.datapoints_orphan_no_applicant.length,
   orphanNoProgram: review.datapoints_orphan_no_program.length,
   orphanBoth: review.datapoints_orphan_both?.length || 0,
+  blockingReviewItems:
+    review.programs_unmapped_tier.length
+    + review.applicants_locked_school_name_blank.length,
   allowSkips,
 });
 if (!integrity.ok) {

--- a/scripts/d1-schema/verify-local.mjs
+++ b/scripts/d1-schema/verify-local.mjs
@@ -10,17 +10,57 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { execSync, spawnSync } from 'node:child_process';
+import { assessMigrationIntegrity, parseAllowSkips } from '../migration-integrity.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
 const DDL = path.join(__dirname, 'migrations', '0001_init.sql');
 const INSERTS_DIR = path.join(REPO_ROOT, 'scripts', 'migration-output');
+const MANUAL_REVIEW = path.join(INSERTS_DIR, 'manual-review.json');
 
 const DB = path.join('/tmp', `csgrad-verify-${Date.now()}.db`);
 
+let allowSkips;
+try {
+  allowSkips = parseAllowSkips(process.argv.slice(2));
+} catch (error) {
+  console.error(`✘ ${error.message}`);
+  process.exit(2);
+}
+
+if (!fs.existsSync(MANUAL_REVIEW)) {
+  console.error(`✘ missing: ${MANUAL_REVIEW}`);
+  process.exit(1);
+}
+const review = JSON.parse(fs.readFileSync(MANUAL_REVIEW, 'utf8'));
+const migrationCounts = review.migration_counts;
+if (!migrationCounts) {
+  console.error('✘ manual-review.json is stale: rerun the migration before verification');
+  process.exit(1);
+}
+const integrity = assessMigrationIntegrity({
+  sourceDatapoints: migrationCounts.source_datapoints,
+  emittedDatapoints: migrationCounts.emitted_datapoints,
+  orphanNoApplicant: review.datapoints_orphan_no_applicant.length,
+  orphanNoProgram: review.datapoints_orphan_no_program.length,
+  orphanBoth: review.datapoints_orphan_both?.length || 0,
+  allowSkips,
+});
+if (!integrity.ok) {
+  console.error(`✘ ${integrity.message}`);
+  process.exit(1);
+}
+if (integrity.overridden) console.warn(`⚠ ${integrity.message}`);
+
 // programs is 280 (not 283): the migration script merges 3 duplicate
 // (school, program) rows from Seatable into their canonicals.
-const EXPECTED = { applicants: 317, programs: 280, datapoints: 1908 };
+const EXPECTED = {
+  applicants: review.expected_counts.applicants,
+  programs: review.expected_counts.programs - review.programs_duplicate_pairs_merged.length,
+  datapoints: allowSkips
+    ? migrationCounts.emitted_datapoints
+    : migrationCounts.source_datapoints,
+};
 
 function sql(query) {
   const r = spawnSync('sqlite3', [DB, query], { encoding: 'utf8' });

--- a/scripts/migrate-seatable-to-d1.mjs
+++ b/scripts/migrate-seatable-to-d1.mjs
@@ -553,10 +553,14 @@ console.log(summary);
 
 const integrity = assessMigrationIntegrity({
   sourceDatapoints: tDP.rows.length,
+  expectedDatapoints: EXPECTED_COUNTS.datapoints,
   emittedDatapoints: dpEmitted,
   orphanNoApplicant: manualReview.datapoints_orphan_no_applicant.length,
   orphanNoProgram: manualReview.datapoints_orphan_no_program.length,
   orphanBoth: manualReview.datapoints_orphan_both.length,
+  blockingReviewItems:
+    manualReview.programs_unmapped_tier.length
+    + manualReview.applicants_locked_school_name_blank.length,
   allowSkips,
 });
 console.log(`\n${integrity.message}`);

--- a/scripts/migrate-seatable-to-d1.mjs
+++ b/scripts/migrate-seatable-to-d1.mjs
@@ -14,6 +14,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { execSync } from 'node:child_process';
+import { assessMigrationIntegrity, parseAllowSkips } from './migration-integrity.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '..');
@@ -22,6 +23,14 @@ const OUTPUT_DIR = path.join(REPO_ROOT, 'scripts', 'migration-output');
 const PROGRAMS_JSON_PATH = path.join(REPO_ROOT, 'static', 'data', 'programs.json');
 
 const EXPECTED_COUNTS = { applicants: 317, programs: 283, datapoints: 1960 };
+
+let allowSkips;
+try {
+  allowSkips = parseAllowSkips(process.argv.slice(2));
+} catch (error) {
+  console.error(`✘ ${error.message}`);
+  process.exit(2);
+}
 
 // ---------- unzip .dtable → tmp dir ----------
 if (!fs.existsSync(DTABLE_PATH)) {
@@ -305,12 +314,13 @@ const manualReview = {
   notes: [
     'TOEFL/IELTS: rows with total ≤ 10 are assumed IELTS, otherwise TOEFL.',
     'programs.tier is NULL when the (school, program) pair did not match static/data/programs.json — needs admin to label tier.',
-    'datapoints without a linked applicant or program are skipped and listed below.',
+    'datapoints without a linked applicant or program are blocked and listed below with their recoverable fields.',
   ],
   programs_unmapped_tier: [],
   programs_duplicate_pairs_merged: [],
   datapoints_orphan_no_applicant: [],
   datapoints_orphan_no_program: [],
+  datapoints_orphan_both: [],
   applicants_locked_school_name_blank: [],
 };
 
@@ -446,29 +456,47 @@ fs.writeFileSync(path.join(OUTPUT_DIR, '002-programs.sql'), programSql.join('\n'
 const dpSql = [
   '-- 003-datapoints.sql — Seatable DataPoints → datapoints',
   '-- Drops the link-formula / formula columns (学位/国家/分数制/GPA/项目文本) — recompute via JOIN at query time.',
-  '-- Rows missing applicant or program link are skipped (see manual-review.json).',
+  '-- Rows missing applicant or program links require explicit --allow-skips (see manual-review.json).',
   'BEGIN TRANSACTION;',
 ];
 let dpEmitted = 0;
+function orphanDetails(row, applicantRowId, programRowId) {
+  return {
+    seatable_row_id: row._id,
+    seatable_dp_id: readAutoNumber(getCell(row, dCols['DataPoints ID'])),
+    applicant_row_id: applicantRowId || null,
+    program_row_id: programRowId || null,
+    result: read(row, dCols, '结果'),
+    academic_year: read(row, dCols, '学年'),
+    semester: read(row, dCols, '学期'),
+    notified_at: read(row, dCols, '通知时间'),
+    submitted_at: read(row, dCols, '网申提交时间'),
+    notes: read(row, dCols, '补充说明 如面试/联系方式等'),
+    creator: row._creator || null,
+    created_at: row._ctime || null,
+  };
+}
 for (const r of tDP.rows) {
   const applicantRowId = dpToApplicant[r._id];
   const programRowId = dpToProgram[r._id];
+  if (!applicantRowId && !programRowId) {
+    manualReview.datapoints_orphan_both.push(orphanDetails(r, applicantRowId, programRowId));
+    continue;
+  }
   if (!applicantRowId) {
-    manualReview.datapoints_orphan_no_applicant.push({ seatable_row_id: r._id });
+    manualReview.datapoints_orphan_no_applicant.push(orphanDetails(r, applicantRowId, programRowId));
     continue;
   }
   if (!programRowId) {
-    manualReview.datapoints_orphan_no_program.push({ seatable_row_id: r._id });
+    manualReview.datapoints_orphan_no_program.push(orphanDetails(r, applicantRowId, programRowId));
     continue;
   }
   const applicantId = applicantIdMap[applicantRowId];
   const programId = programIdMap[programRowId];
   if (!applicantId || !programId) {
-    manualReview.datapoints_orphan_no_applicant.push({
-      seatable_row_id: r._id,
+    manualReview.datapoints_orphan_both.push({
+      ...orphanDetails(r, applicantRowId, programRowId),
       reason: 'link target not found in id maps',
-      applicant_row: applicantRowId,
-      program_row: programRowId,
     });
     continue;
   }
@@ -496,6 +524,11 @@ dpSql.push('COMMIT;');
 fs.writeFileSync(path.join(OUTPUT_DIR, '003-datapoints.sql'), dpSql.join('\n') + '\n');
 
 // ---------- manual-review.json + summary.txt ----------
+manualReview.migration_counts = {
+  source_datapoints: tDP.rows.length,
+  emitted_datapoints: dpEmitted,
+  skipped_datapoints: tDP.rows.length - dpEmitted,
+};
 fs.writeFileSync(
   path.join(OUTPUT_DIR, 'manual-review.json'),
   JSON.stringify(manualReview, null, 2) + '\n',
@@ -505,15 +538,27 @@ const summary = [
   '=== Migration summary ===',
   `applicants:  emitted=${tApp.rows.length}   expected=${EXPECTED_COUNTS.applicants}   ${tApp.rows.length === EXPECTED_COUNTS.applicants ? 'OK' : 'MISMATCH'}`,
   `programs:    emitted=${programEmitted}   merged-dupes=${programDuplicatesReview.length}   seatable-rows=${tProg.rows.length}   expected=${EXPECTED_COUNTS.programs}`,
-  `datapoints:  emitted=${dpEmitted}   skipped=${tDP.rows.length - dpEmitted}   expected~${EXPECTED_COUNTS.datapoints}`,
+  `datapoints:  source=${tDP.rows.length}   emitted=${dpEmitted}   skipped=${tDP.rows.length - dpEmitted}   expected=${EXPECTED_COUNTS.datapoints}`,
   '',
   '=== Manual-review queue ===',
   `programs without tier:             ${manualReview.programs_unmapped_tier.length}`,
   `programs duplicate-pairs merged:   ${manualReview.programs_duplicate_pairs_merged.length}`,
-  `datapoints orphan (no applicant):  ${manualReview.datapoints_orphan_no_applicant.length}`,
-  `datapoints orphan (no program):    ${manualReview.datapoints_orphan_no_program.length}`,
+  `datapoints orphan (applicant only): ${manualReview.datapoints_orphan_no_applicant.length}`,
+  `datapoints orphan (program only):   ${manualReview.datapoints_orphan_no_program.length}`,
+  `datapoints orphan (both links):     ${manualReview.datapoints_orphan_both.length}`,
   `applicants with blank 本科学校名称:  ${manualReview.applicants_locked_school_name_blank.length}`,
 ].join('\n');
 fs.writeFileSync(path.join(OUTPUT_DIR, 'summary.txt'), summary + '\n');
 console.log(summary);
-console.log(`\n✔ output written to ${OUTPUT_DIR}`);
+
+const integrity = assessMigrationIntegrity({
+  sourceDatapoints: tDP.rows.length,
+  emittedDatapoints: dpEmitted,
+  orphanNoApplicant: manualReview.datapoints_orphan_no_applicant.length,
+  orphanNoProgram: manualReview.datapoints_orphan_no_program.length,
+  orphanBoth: manualReview.datapoints_orphan_both.length,
+  allowSkips,
+});
+console.log(`\n${integrity.message}`);
+console.log(`✔ output written to ${OUTPUT_DIR}`);
+if (!integrity.ok) process.exitCode = 1;

--- a/scripts/migration-integrity.mjs
+++ b/scripts/migration-integrity.mjs
@@ -1,0 +1,55 @@
+export function assessMigrationIntegrity({
+  sourceDatapoints,
+  emittedDatapoints,
+  orphanNoApplicant,
+  orphanNoProgram,
+  orphanBoth = 0,
+  allowSkips = false,
+}) {
+  const skippedDatapoints = sourceDatapoints - emittedDatapoints;
+  const classifiedOrphans = orphanNoApplicant + orphanNoProgram + orphanBoth;
+  const complete = skippedDatapoints === 0 && classifiedOrphans === 0;
+  const counts = `source=${sourceDatapoints} emitted=${emittedDatapoints} skipped=${skippedDatapoints}`;
+
+  if (skippedDatapoints !== classifiedOrphans) {
+    return {
+      ok: false,
+      overridden: false,
+      skippedDatapoints,
+      message: `INCONSISTENT: ${counts} classified=${classifiedOrphans}`,
+    };
+  }
+
+  if (complete) {
+    return {
+      ok: true,
+      overridden: false,
+      skippedDatapoints,
+      message: `COMPLETE: ${counts}`,
+    };
+  }
+
+  if (allowSkips) {
+    return {
+      ok: true,
+      overridden: true,
+      skippedDatapoints,
+      message: `INCOMPLETE/OVERRIDDEN: ${counts}`,
+    };
+  }
+
+  return {
+    ok: false,
+    overridden: false,
+    skippedDatapoints,
+    message: `INCOMPLETE: ${counts}; rerun with --allow-skips only after reviewing every orphan`,
+  };
+}
+
+export function parseAllowSkips(argv) {
+  const unknown = argv.filter((arg) => arg !== '--allow-skips');
+  if (unknown.length > 0) {
+    throw new Error(`unknown argument(s): ${unknown.join(', ')}`);
+  }
+  return argv.includes('--allow-skips');
+}

--- a/scripts/migration-integrity.mjs
+++ b/scripts/migration-integrity.mjs
@@ -1,14 +1,20 @@
 export function assessMigrationIntegrity({
   sourceDatapoints,
+  expectedDatapoints,
   emittedDatapoints,
   orphanNoApplicant,
   orphanNoProgram,
   orphanBoth = 0,
+  blockingReviewItems = 0,
   allowSkips = false,
 }) {
   const skippedDatapoints = sourceDatapoints - emittedDatapoints;
   const classifiedOrphans = orphanNoApplicant + orphanNoProgram + orphanBoth;
-  const complete = skippedDatapoints === 0 && classifiedOrphans === 0;
+  const sourceMatchesExpected = sourceDatapoints === expectedDatapoints;
+  const complete = sourceMatchesExpected
+    && skippedDatapoints === 0
+    && classifiedOrphans === 0
+    && blockingReviewItems === 0;
   const counts = `source=${sourceDatapoints} emitted=${emittedDatapoints} skipped=${skippedDatapoints}`;
 
   if (skippedDatapoints !== classifiedOrphans) {
@@ -17,6 +23,15 @@ export function assessMigrationIntegrity({
       overridden: false,
       skippedDatapoints,
       message: `INCONSISTENT: ${counts} classified=${classifiedOrphans}`,
+    };
+  }
+
+  if (!sourceMatchesExpected && !allowSkips) {
+    return {
+      ok: false,
+      overridden: false,
+      skippedDatapoints,
+      message: `SOURCE_MISMATCH: ${counts} expected=${expectedDatapoints}`,
     };
   }
 
@@ -34,7 +49,7 @@ export function assessMigrationIntegrity({
       ok: true,
       overridden: true,
       skippedDatapoints,
-      message: `INCOMPLETE/OVERRIDDEN: ${counts}`,
+      message: `INCOMPLETE/OVERRIDDEN: ${counts} expected=${expectedDatapoints} blocking_review=${blockingReviewItems}`,
     };
   }
 
@@ -42,7 +57,7 @@ export function assessMigrationIntegrity({
     ok: false,
     overridden: false,
     skippedDatapoints,
-    message: `INCOMPLETE: ${counts}; rerun with --allow-skips only after reviewing every orphan`,
+    message: `INCOMPLETE: ${counts} expected=${expectedDatapoints} blocking_review=${blockingReviewItems}; rerun with --allow-skips only after reviewing every blocking item`,
   };
 }
 

--- a/scripts/migration-integrity.test.mjs
+++ b/scripts/migration-integrity.test.mjs
@@ -6,6 +6,7 @@ import { assessMigrationIntegrity, parseAllowSkips } from './migration-integrity
 test('rejects a migration that silently skips datapoints', () => {
   const result = assessMigrationIntegrity({
     sourceDatapoints: 1960,
+    expectedDatapoints: 1960,
     emittedDatapoints: 1908,
     orphanNoApplicant: 24,
     orphanNoProgram: 7,
@@ -21,6 +22,7 @@ test('rejects a migration that silently skips datapoints', () => {
 test('allows an incomplete migration only with an explicit override', () => {
   const result = assessMigrationIntegrity({
     sourceDatapoints: 1960,
+    expectedDatapoints: 1960,
     emittedDatapoints: 1908,
     orphanNoApplicant: 24,
     orphanNoProgram: 7,
@@ -36,6 +38,7 @@ test('allows an incomplete migration only with an explicit override', () => {
 test('accepts a complete migration without an override', () => {
   const result = assessMigrationIntegrity({
     sourceDatapoints: 1960,
+    expectedDatapoints: 1960,
     emittedDatapoints: 1960,
     orphanNoApplicant: 0,
     orphanNoProgram: 0,
@@ -54,6 +57,7 @@ test('rejects unknown CLI arguments', () => {
 test('never accepts an unaccounted row, even with an override', () => {
   const result = assessMigrationIntegrity({
     sourceDatapoints: 1960,
+    expectedDatapoints: 1960,
     emittedDatapoints: 1908,
     orphanNoApplicant: 24,
     orphanNoProgram: 7,
@@ -63,4 +67,33 @@ test('never accepts an unaccounted row, even with an override', () => {
 
   assert.equal(result.ok, false);
   assert.match(result.message, /classified=51/);
+});
+
+test('rejects a complete-looking migration from a truncated source', () => {
+  const result = assessMigrationIntegrity({
+    sourceDatapoints: 1908,
+    expectedDatapoints: 1960,
+    emittedDatapoints: 1908,
+    orphanNoApplicant: 0,
+    orphanNoProgram: 0,
+    allowSkips: false,
+  });
+
+  assert.equal(result.ok, false);
+  assert.match(result.message, /SOURCE_MISMATCH/);
+});
+
+test('rejects blocking manual-review items without an override', () => {
+  const result = assessMigrationIntegrity({
+    sourceDatapoints: 1960,
+    expectedDatapoints: 1960,
+    emittedDatapoints: 1960,
+    orphanNoApplicant: 0,
+    orphanNoProgram: 0,
+    blockingReviewItems: 1,
+    allowSkips: false,
+  });
+
+  assert.equal(result.ok, false);
+  assert.match(result.message, /blocking_review=1/);
 });

--- a/scripts/migration-integrity.test.mjs
+++ b/scripts/migration-integrity.test.mjs
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { assessMigrationIntegrity, parseAllowSkips } from './migration-integrity.mjs';
+
+test('rejects a migration that silently skips datapoints', () => {
+  const result = assessMigrationIntegrity({
+    sourceDatapoints: 1960,
+    emittedDatapoints: 1908,
+    orphanNoApplicant: 24,
+    orphanNoProgram: 7,
+    orphanBoth: 21,
+    allowSkips: false,
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.skippedDatapoints, 52);
+  assert.match(result.message, /source=1960 emitted=1908 skipped=52/);
+});
+
+test('allows an incomplete migration only with an explicit override', () => {
+  const result = assessMigrationIntegrity({
+    sourceDatapoints: 1960,
+    emittedDatapoints: 1908,
+    orphanNoApplicant: 24,
+    orphanNoProgram: 7,
+    orphanBoth: 21,
+    allowSkips: true,
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.overridden, true);
+  assert.match(result.message, /INCOMPLETE\/OVERRIDDEN/);
+});
+
+test('accepts a complete migration without an override', () => {
+  const result = assessMigrationIntegrity({
+    sourceDatapoints: 1960,
+    emittedDatapoints: 1960,
+    orphanNoApplicant: 0,
+    orphanNoProgram: 0,
+    allowSkips: false,
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.overridden, false);
+  assert.match(result.message, /COMPLETE/);
+});
+
+test('rejects unknown CLI arguments', () => {
+  assert.throws(() => parseAllowSkips(['--typo']), /unknown argument/);
+});
+
+test('never accepts an unaccounted row, even with an override', () => {
+  const result = assessMigrationIntegrity({
+    sourceDatapoints: 1960,
+    emittedDatapoints: 1908,
+    orphanNoApplicant: 24,
+    orphanNoProgram: 7,
+    orphanBoth: 20,
+    allowSkips: true,
+  });
+
+  assert.equal(result.ok, false);
+  assert.match(result.message, /classified=51/);
+});


### PR DESCRIPTION
## Summary
- classify 52 orphaned DataPoints precisely: 24 applicant-only, 7 program-only, 21 missing both links
- preserve recoverable orphan fields in manual-review.json and fail closed by default
- require explicit --allow-skips for diagnostic incomplete artifacts
- validate expected source count and blocking review queues
- remove the hard-coded 1908 success condition from local verification

## Root cause
The SeaTable export link maps are incomplete. The migration used continue for missing links, then verify-local hard-coded the truncated count as expected. Twelve skipped rows contain real outcomes, so guessing relationships would be unsafe.

## Verification
- npm run test:migration
- full migration in a temporary copy: default exit 1; --allow-skips exit 0
- verify-local: default exit 1; --allow-skips completes SQLite/FK checks
- npm run build (passes; pre-existing broken-link warnings remain)