### PR TITLE
Temporarily disable school positioning

### DIFF
--- a/docs/intro.mdx
+++ b/docs/intro.mdx
@@ -15,8 +15,6 @@ import VisitorGeoMap from '@site/src/components/VisitorGeoMap';
 
 **[DataPoints 上线](/datapoints)** — 全新 UI 改版，收录历史 **1908 条** MSCS 申请录取数据，支持按学校 / Tier / 年份 / 结果 / 本科档次 / 专业等多维筛选；点击任意行可查看该申请者的全部 DP。同时[可提交你自己的 DP](/submit-dp)。
 
-**[选校定位](/school-positioning)** — 填一遍背景，立刻得到你的 **档位评级** 和 **reach / match / safety 三档选校建议**。
-
 :::
 
 CS Grad 项目专注于北美 MSCS 申请，涵盖 CS、DS、EE、ECE、IS 等相关专业的介绍。Motivation 是帮助来自 **中国大陆** 和 **北美本科** 的申请者更高效地了解各项目的定位及其 **实际价值**。与侧重录取门槛（admission bar）排名的 Open CS App 不同，CS Grad 更关注 **项目的真实价值**，尤其是在北美 **SDE求职** 方面的帮助，而 **非单纯的录取难度**。
@@ -68,4 +66,3 @@ contributor讨论计算得出的，难免会有bias，欢迎大家提pr修正**
 4. 读研只是实现人生理想的方法，读研不是避风港，人生也不会永远静止在拿到offer的那一天
 
 <VisitorGeoMap />
-

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -96,11 +96,6 @@ const config = {
             label: 'DataPoints',
           },
           {
-            to: '/school-positioning',
-            position: 'left',
-            label: '选校定位',
-          },
-          {
             to: '/tracker',
             position: 'left',
             label: '申请跟踪',

--- a/i18n/en/docusaurus-theme-classic/navbar.json
+++ b/i18n/en/docusaurus-theme-classic/navbar.json
@@ -22,9 +22,5 @@
   "item.label.GitHub": {
     "message": "GitHub",
     "description": "Navbar item with label GitHub"
-  },
-  "item.label.选校定位": {
-    "message": "Positioning",
-    "description": "Navbar item with label 选校定位"
   }
 }

--- a/src/pages/school-positioning.jsx
+++ b/src/pages/school-positioning.jsx
@@ -7,6 +7,7 @@ import { FIELD_DEFINITIONS } from '@site/src/lib/positioning/profile-schema';
 import { WORKER_BASE_URL } from '@site/src/lib/positioning/api';
 import styles from './school-positioning.module.css';
 
+const POSITIONING_AVAILABLE = false;
 
 const COPY = {
   'zh-Hans': {
@@ -43,6 +44,10 @@ const COPY = {
     yes: '是',
     no: '否',
     selectPlaceholder: '请选择',
+    offlineStatus: '暂时下线',
+    offlineTitle: '选校定位暂时下线',
+    offlineLead: '我们正在调整定位模型与结果质量，暂时停止新的定位和支付。',
+    offlineExisting: '已购买用户仍可通过付款后收到的结果链接查看和下载报告。',
   },
   en: {
     pageTitle: 'MSCS School Positioning',
@@ -78,6 +83,10 @@ const COPY = {
     yes: 'Yes',
     no: 'No',
     selectPlaceholder: 'Select…',
+    offlineStatus: 'Temporarily unavailable',
+    offlineTitle: 'School positioning is temporarily offline',
+    offlineLead: 'We are improving the positioning model and result quality. New assessments and payments are paused for now.',
+    offlineExisting: 'Existing customers can still open and download their report from the result link received after payment.',
   },
 };
 
@@ -89,6 +98,24 @@ function getLabel(node, locale) {
   if (!node) return '';
   if (typeof node === 'string') return node;
   return node[locale] || node['zh-Hans'] || node.en || '';
+}
+
+function OfflineNotice({ locale, t }) {
+  return (
+    <div className={styles.pageWrapper}>
+      <div className={styles.container}>
+        <a href={locale === 'en' ? '/en/' : '/'} className={styles.backLink}>
+          &larr; {t.backHome}
+        </a>
+        <section className={styles.hero} aria-labelledby="positioning-offline-title">
+          <span className={styles.offlineStatus}>{t.offlineStatus}</span>
+          <h1 id="positioning-offline-title" className={styles.title}>{t.offlineTitle}</h1>
+          <p className={styles.lead}>{t.offlineLead}</p>
+          <p className={styles.offlineExisting}>{t.offlineExisting}</p>
+        </section>
+      </div>
+    </div>
+  );
 }
 
 function initialFieldValue(f) {
@@ -576,17 +603,21 @@ export default function SchoolPositioningPage() {
   const { i18n } = useDocusaurusContext();
   const locale = pickLocale(i18n.currentLocale);
   const t = COPY[locale];
+  const pageTitle = POSITIONING_AVAILABLE ? t.pageTitle : t.offlineTitle;
+  const pageDesc = POSITIONING_AVAILABLE ? t.pageDesc : t.offlineLead;
   return (
-    <Layout title={t.pageTitle} description={t.pageDesc}>
+    <Layout title={pageTitle} description={pageDesc}>
       <Head>
-        <meta name="description" content={t.pageDesc} />
-        <meta property="og:title" content={t.pageTitle} />
-        <meta property="og:description" content={t.pageDesc} />
+        <meta name="description" content={pageDesc} />
+        <meta property="og:title" content={pageTitle} />
+        <meta property="og:description" content={pageDesc} />
         <meta property="og:type" content="website" />
       </Head>
-      <BrowserOnly fallback={<div className={styles.pageWrapper} />}>
-        {() => <FormBody />}
-      </BrowserOnly>
+      {POSITIONING_AVAILABLE ? (
+        <BrowserOnly fallback={<div className={styles.pageWrapper} />}>
+          {() => <FormBody />}
+        </BrowserOnly>
+      ) : <OfflineNotice locale={locale} t={t} />}
     </Layout>
   );
 }

--- a/src/pages/school-positioning.module.css
+++ b/src/pages/school-positioning.module.css
@@ -63,6 +63,38 @@
   margin: 0 0 12px;
 }
 
+.offlineStatus {
+  display: inline-block;
+  margin-bottom: 14px;
+  padding: 4px 10px;
+  border: 1px solid rgba(201, 169, 110, 0.45);
+  border-radius: 999px;
+  background: rgba(201, 169, 110, 0.1);
+  color: #8a6232;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+.offlineExisting {
+  margin: 18px 0 0;
+  padding-top: 16px;
+  border-top: 1px solid #eee5d8;
+  color: #6f6255;
+  font-size: 0.88rem;
+  line-height: 1.6;
+}
+
+[data-theme='dark'] .offlineStatus {
+  color: #d8bd91;
+  border-color: rgba(201, 169, 110, 0.35);
+}
+
+[data-theme='dark'] .offlineExisting {
+  color: #a99b8c;
+  border-top-color: #3a3530;
+}
+
 [data-theme='dark'] .lead {
   color: #a09080;
 }


### PR DESCRIPTION
## 变更\n- 移除导航栏中的选校定位入口\n- 移除主页的选校定位介绍\n- 定位页改为中英文暂时下线提示，停止新定位和支付\n- 保留已购用户结果页及后端逻辑，方便后续恢复\n\n## 验证\n- npm run build（中英文构建通过）\n- 页面检查：导航与主页入口已移除，定位页下线提示正常\n\n备注：构建仍报告项目原有的 3 个失效文档链接警告，本 PR 未新增链接警告。