### PR TITLE
将辅导案例迁移到独立过往 DP 页面

### DIFF
--- a/docs/找我辅导.md
+++ b/docs/找我辅导.md
@@ -8,19 +8,7 @@
 * **25fall：** 一共带了三位同学，分别申请到了 Cornell CS MENG, CMU SESV, Uchicago MPCS。
 * **26fall：** 目前带的同学拿到的 offer 包括：Harvard CSE * 1, Uchicago MPCS offer * 3, CMU MSIN offer * 1, Cornell Tech CM offer * 1, CMU MISM offer * 1, UCI MSWE * 1（详细 offer 和 timeline 请看小红书）。
 
-![TOP 40 美本 MATH + CS，录取 Harvard CSE](/img/dp-cases/harvard-cse.png)
-
-![NYU 本科，录取 CMU MSIN 案例之一](/img/dp-cases/nyu-cmu-msin-01.png)
-
-![NYU 本科，录取 CMU MSIN 案例之二](/img/dp-cases/nyu-cmu-msin-02.png)
-
-![交大与 UMich 合办本科，录取 Cornell MEng CS](/img/dp-cases/umich-cornell-meng-cs.png)
-
-![中外合办本科，录取 CMU SESV](/img/dp-cases/joint-cmu-sesv.png)
-
-![交大与 UMich 合办本科，录取 UChicago CS](/img/dp-cases/umich-uchicago-cs.png)
-
-![UCLA CS 本科，录取 CMU MISM 和 UIUC MCS，最终选择美国大厂 New Grad SDE](/img/dp-cases/ucla-cmu-mism-uiuc-mcs-new-grad-sde.png)
+[查看过往 DP、申请背景与录取结果 →](/past-dp)
 
 ---
 

--- a/docs/过往DP.mdx
+++ b/docs/过往DP.mdx
@@ -1,0 +1,47 @@
+---
+title: 过往 DP
+slug: /past-dp
+description: 过往辅导学员的申请背景、录取结果与真实截图。
+---
+
+以下案例展示了部分过往学员的实际升学与求职结果。为保护学员隐私，截图中的姓名、联系方式及其他可识别信息均已隐去。
+
+## 案例一：TOP 40 美本 MATH + CS，录取 Harvard CSE
+
+GPA 3.9+，无实习经历；有科研经历并有产出。
+
+<img src="/img/dp-cases/harvard-cse.png" alt="TOP 40 美本 MATH 与 CS 专业学生录取 Harvard CSE 的案例截图" style={{display: 'block', width: '90%', height: 'auto', margin: '0 auto'}} />
+
+## 案例二：NYU 本科，录取 CMU MSIN
+
+GPA 3.6，有实习经历，无科研产出。
+
+<img src="/img/dp-cases/nyu-cmu-msin-01.png" alt="NYU 本科学生录取 CMU MSIN 的聊天记录之一" style={{display: 'block', width: '90%', height: 'auto', margin: '0 auto'}} />
+
+## 案例二（续）：NYU 本科，录取 CMU MSIN
+
+<img src="/img/dp-cases/nyu-cmu-msin-02.png" alt="NYU 本科学生录取 CMU MSIN 的聊天记录之二" style={{display: 'block', width: '90%', height: 'auto', margin: '0 auto'}} />
+
+## 案例三：交大与 UMich 合办本科，录取 CMU 与 Cornell MEng CS
+
+GPA 3.8 左右，有 AI 经历但项目深度有限；最终选择 Cornell MEng CS。
+
+<img src="/img/dp-cases/umich-cornell-meng-cs.png" alt="交大与 UMich 合办本科学生录取 CMU 与 Cornell MEng CS 的案例截图" style={{display: 'block', width: '90%', height: 'auto', margin: '0 auto'}} />
+
+## 案例四：中外合办本科，录取 CMU SESV
+
+美方合作院校排名 Top 100 开外；有家里安排的实习和校内科研经历，但科研无产出。
+
+<img src="/img/dp-cases/joint-cmu-sesv.png" alt="中外合办本科学生录取 CMU SESV 的案例截图" style={{display: 'block', width: '90%', height: 'auto', margin: '0 auto'}} />
+
+## 案例五：交大与 UMich 合办本科，录取 UChicago CS
+
+GPA 3.6 左右，有 AI 产出，工业界背景偏弱。
+
+<img src="/img/dp-cases/umich-uchicago-cs.png" alt="交大与 UMich 合办本科学生录取 UChicago CS 的案例截图" style={{display: 'block', width: '90%', height: 'auto', margin: '0 auto'}} />
+
+## 案例六：UCLA CS 本科，录取 CMU MISM 与 UIUC MCS
+
+GPA 约 3.7，仅有黑马点评项目，无实习、无科研；最终选择美国大厂 New Grad SDE。
+
+<img src="/img/dp-cases/ucla-cmu-mism-uiuc-mcs-new-grad-sde.png" alt="UCLA CS 本科学生录取 CMU MISM 和 UIUC MCS 并选择 New Grad SDE 的案例截图" style={{display: 'block', width: '90%', height: 'auto', margin: '0 auto'}} />


### PR DESCRIPTION
## 改动
- 从“找我辅导”页面移除 7 张案例图
- 新增独立“过往 DP”页面，按照合同中的案例顺序和 90% 居中图片排布展示
- 为每个案例补充简短申请背景与录取/去向说明
- 在“找我辅导”案例 section 添加跳转到独立页面的链接

## 验证
- npm run build（中英文站点均构建成功）
- 已确认 /past-dp 构建产物包含全部 7 张最终案例图
- 构建仍有 3 个仓库原有的“转码项目”旧链接警告，与本次改动无关

此 PR 等待确认，不自动合并。