### PR TITLE
更新 Info Session 邮件参会通知

### DIFF
--- a/docs/intro.mdx
+++ b/docs/intro.mdx
@@ -11,15 +11,11 @@ import VisitorGeoMap from '@site/src/components/VisitorGeoMap';
 ![License: CC BY-NC-SA 4.0](https://img.shields.io/badge/License-CC%20BY--NC--SA%204.0-lightgrey.svg)
 [![GitHub Repo stars](https://img.shields.io/github/stars/csms-apply/csgrad)](https://github.com/csms-apply/csgrad)
 
-:::tip 📢 直播预告：预计美西时间 8 月 28 日晚 8:00 开播
+:::tip 📬 Info Session 参会链接已发送
 
-**主题：27 Fall 申请变化与 CPT 政策影响**
+Csgrad 27 Fall MSCS 申请趋势 Info Session 的 Google Meet 参会链接，已经发送到大家报名时填写的邮箱。
 
-聊聊 27 Fall 申请季可能出现的新变化，以及“CPT 被取消”的传闻到底会不会影响留学申请、实习与求职规划；同时分享几个去年的真实申请 DP 案例。
-
-**[填写 Google Form，预约直播](https://forms.gle/tRbzzayD8xEmSCsf6)**
-
-**报名截止：美西时间 8 月 25 日晚 11:59**
+如果收件箱里没有找到，请检查 **Spam / 垃圾邮件** 文件夹。
 
 :::
 


### PR DESCRIPTION
## 修改内容

- 将首页直播预约提示更新为参会链接已发送
- 明确链接发送至报名时填写的邮箱
- 提醒未收到时检查 Spam / 垃圾邮件文件夹
- 补充活动在三个时区的时间：
  - 美西：8 月 29 日（星期六）晚上 8:00–9:00
  - 美东：8 月 29 日（星期六）晚上 11:00–次日凌晨 12:00
  - 中国大陆：8 月 30 日（星期日）上午 11:00–中午 12:00

## 验证

- `npm run build` 通过
- 构建仍报告仓库已有的转码项目断链警告，本次未新增链接或警告