### PR TITLE
补充 Info Session 三地时间

### DIFF
--- a/docs/intro.mdx
+++ b/docs/intro.mdx
@@ -15,6 +15,12 @@ import VisitorGeoMap from '@site/src/components/VisitorGeoMap';
 
 Csgrad 27 Fall MSCS 申请趋势 Info Session 的 Google Meet 参会链接，已经发送到大家报名时填写的邮箱。
 
+**活动时间：**
+
+- **美西时间：8 月 29 日（星期六）晚上 8:00–9:00**
+- **美东时间：8 月 29 日（星期六）晚上 11:00–次日凌晨 12:00**
+- **中国大陆时间：8 月 30 日（星期日）上午 11:00–中午 12:00**
+
 如果收件箱里没有找到，请检查 **Spam / 垃圾邮件** 文件夹。
 
 :::


### PR DESCRIPTION
## 修改内容

在首页 Info Session 参会通知中补充三个时区的活动时间：

- 美西：8 月 29 日（星期六）晚上 8:00–9:00
- 美东：8 月 29 日（星期六）晚上 11:00–次日凌晨 12:00
- 中国大陆：8 月 30 日（星期日）上午 11:00–中午 12:00

继续保留“参会链接已发送到报名邮箱”和“未找到请检查 Spam / 垃圾邮件”的提示。

## 验证

- `npm run build` 通过
- 仓库原有的转码项目断链警告未增加