### PR TITLE
feat: 前端改用 CSGrad 同域后端

### DIFF
--- a/src/lib/dp/api.js
+++ b/src/lib/dp/api.js
@@ -1,6 +1,6 @@
 // Client for the DataPoints API.
 //
-// Row data always comes from the live worker via /api/dp. The static
+// Row data always comes from the same-origin backend via /api/dp. The static
 // dp-snapshot.json is now slim — only filter-option lists + total counts —
 // used to populate filter dropdowns and header counts before the API
 // responds. There is no full-snapshot fallback for rows.
@@ -8,7 +8,7 @@
 import { WORKER_BASE_URL } from '../positioning/api';
 import { LIST_LIMIT_API } from './config';
 
-export const DP_API_BASE = WORKER_BASE_URL; // same worker as positioning
+export const DP_API_BASE = WORKER_BASE_URL; // same-origin backend shared with positioning
 
 // In production builds we want fallback errors to stay silent (resilience is a
 // feature). In dev, surface them via console.warn so debugging is easier.
@@ -93,7 +93,7 @@ const TIER_ORDER = ['SSS', 'SS', 'S', 'A+', 'A', 'A-', 'B+', 'B', 'B-', 'C+', 'C
 
 /**
  * Returns the filter-option lists used by the DataPoints page filters.
- * Prefers the live worker (/api/filter-options) so newly submitted DPs'
+ * Prefers the live API (/api/filter-options) so newly submitted DPs'
  * schools / majors / years show up in the dropdowns; falls back to the
  * frozen snapshot if the worker is unreachable.
  * @returns {Promise<{schools: string[], tiers: string[], years: number[], ugCats: string[], majors: string[]}>}
@@ -142,15 +142,16 @@ function reorderTiers(opts) {
 // ---------- helpers ----------
 
 function buildUrl(path, params) {
-  const url = new URL(path, DP_API_BASE);
+  const search = new URLSearchParams();
   for (const [k, v] of Object.entries(params)) {
     if (v == null || v === '') continue;
-    url.searchParams.set(k, String(v));
+    search.set(k, String(v));
   }
-  return url.toString();
+  const query = search.toString();
+  return `${DP_API_BASE}${path}${query ? `?${query}` : ''}`;
 }
 
-// Counts for the header. Prefer the live worker (/api/stats) so newly
+// Counts for the header. Prefer the live API (/api/stats) so newly
 // submitted DPs are reflected; fall back to the frozen snapshot if the
 // worker is unreachable.
 export async function getCounts() {

--- a/src/lib/positioning/api.js
+++ b/src/lib/positioning/api.js
@@ -1,1 +1,8 @@
-export const WORKER_BASE_URL = 'https://csgrad-positioning.capsfly7.workers.dev';
+// The API is served by the same nginx host as the Docusaurus site. Keeping the
+// base empty produces relative `/api/...` URLs, so csgrad.com and
+// www.csgrad.com each retain a first-party login cookie.
+export const API_BASE_URL = '';
+
+// Compatibility name used by the positioning pages while the old Worker is
+// kept online as a rollback target.
+export const WORKER_BASE_URL = API_BASE_URL;


### PR DESCRIPTION
## 变更\n- DataPoints、OAuth 和选校定位统一请求同域 /api\n- 移除浏览器对 csgrad-positioning.capsfly7.workers.dev 的直接依赖\n- 保留旧常量名作为迁移兼容，Worker 可继续作为回滚目标\n\n## 验证\n- npm run build 成功（zh-Hans + en）\n- 仅保留仓库原有的 3 个转码项目失效链接 warning\n\n## 发布顺序\n此 PR 必须等 VPS 后端、D1 数据、密钥和 Nginx /api 代理就绪后再合并，否则线上 API 会暂时不可用。\n