### PR TITLE
Fix English site localization and broken data pages

### DIFF
--- a/docs/转码项目.md
+++ b/docs/转码项目.md
@@ -21,10 +21,10 @@
 
 
 ## 需要修过部分先修课
-1. [Duke ECE](B+/duke%20ece.md)
+1. [Duke ECE](A-/duke%20ece.md)
 2. Duke game design
 3. [Columbia MSCS](A/columbia%20mscs.md)
-4. [Columbia EE](A-/Columbia%20ee.md)
+4. [Columbia EE](B+/Columbia%20ee.md)
 5. [CMU MSIN](S/cmu%20msin.md)(往年有临床医学5年制本科修够先修课转码的DP，也有不少EE/IS/网安的同学申请到)
 6. [CMU MISM](B+/cmu%20mism.md)
 7. [Emory MSCS](B/Emory%20MSCS.md)
@@ -32,5 +32,5 @@
 9. [Gatech CSE](A+/Gatech%20CSE.md)(可以先申请冷门track，比如isye，然后进去转MSCS转码)
 10. [UIUC ECE](B/UIUC%20ECE%20MENG.md)
 11. [UW EE PMP](A/uw%20ee%20pmp.md)
-12. [NCSU MCS](B-/NCSU%20MCS.md)
+12. [NCSU MCS](B/NCSU%20MCS.md)
 13. [NEU IS](B-/NEU%20IS.md)

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -10,7 +10,7 @@ import {themes as prismThemes} from 'prism-react-renderer';
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
-  title: '美研mscs介绍',
+  title: 'CS Grad',
   tagline: 'Make application easier',
   favicon: 'img/favicon.ico',
 
@@ -80,7 +80,7 @@ const config = {
       navbar: {
         title: 'cs grad',
         logo: {
-          alt: 'My Site Logo',
+          alt: 'CS Grad Logo',
           src: 'img/logo.svg',
         },
         items: [
@@ -115,11 +115,19 @@ const config = {
         style: 'dark',
         links: [
           {
-            title: 'Docs',
+            title: 'Explore',
             items: [
               {
-                label: 'Tutorial',
+                label: 'Program Guide',
                 to: '/',
+              },
+              {
+                label: 'Data Points',
+                to: '/datapoints',
+              },
+              {
+                label: 'Application Tracker',
+                to: '/tracker',
               },
             ],
           },
@@ -127,21 +135,13 @@ const config = {
             title: 'Community',
             items: [
               {
-                label: 'Stack Overflow',
-                href: 'https://stackoverflow.com/questions/tagged/docusaurus',
-              },
-              {
-                label: 'Discord',
-                href: 'https://discordapp.com/invite/docusaurus',
-              },
-              {
-                label: 'X',
-                href: 'https://x.com/docusaurus',
+                label: 'CS Grad Discord',
+                href: 'https://discord.gg/g9x4WCX2xz',
               },
             ],
           },
           {
-            title: 'More',
+            title: 'Project',
             items: [
               {
                 label: 'GitHub',
@@ -150,7 +150,7 @@ const config = {
             ],
           },
         ],
-        copyright: `Copyright © ${new Date().getFullYear()} 红尘客栈_`,
+        copyright: `Copyright © ${new Date().getFullYear()} CS Grad`,
       },
       prism: {
         theme: prismThemes.github,

--- a/i18n/en/docusaurus-plugin-content-docs/current.json
+++ b/i18n/en/docusaurus-plugin-content-docs/current.json
@@ -55,8 +55,8 @@
     "message": "Career Change Programs",
     "description": "The label for the doc item 转码项目合集 in sidebar tutorialSidebar, linking to the doc 转码项目"
   },
-  "sidebar.tutorialSidebar.doc.找我辅导": {
-    "message": "Consulting",
-    "description": "The label for the doc item 找我辅导 in sidebar tutorialSidebar, linking to the doc 找我辅导"
+  "sidebar.tutorialSidebar.doc.找CS Grad作者辅导": {
+    "message": "Work with the CS Grad Author",
+    "description": "The label for the consulting page in sidebar tutorialSidebar"
   }
 }

--- a/i18n/en/docusaurus-plugin-content-docs/current/A+/UCLA MENG.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/A+/UCLA MENG.md
@@ -8,11 +8,11 @@ The program itself is a Master of Engineering (MEng) under the Samueli School of
 
 2023 Fall admitted about 150 students, mainly concentrated in the Data Science and AI tracks. Most students are Chinese, with a good mix of undergrads from mainland China and international undergrads.
 
-However, starting from 24 Fall, whether you can defer has become uncertain. The program director is also irresponsible and often doesn't reply to emails. Students entering in 24 Fall didn't even know whether the program could be deferred or whether they could get CPT. Be mentally prepared if you want to come.
+Beginning with the Fall 2024 cohort, policies around deferral and CPT became less predictable, and students reported slow or inconsistent responses from program administration. Applicants who need either option should obtain written confirmation directly from the program before making a decision.
 
-## Admission Threshold & Data Points
+## Typical Admitted Profiles
 GPA 3.7+ and GRE 325+
-1. 211 university, Software Engineering undergrad, GPA 3.98
+1. Project 211 university, Software Engineering undergrad, GPA 3.98
 2. SJTU CS undergrad, GPA 88, TOEFL 105
 3. SJTU Automation undergrad, GPA 3.55, TOEFL 106
 4. Nankai CS undergrad, GPA 86, TOEFL 104
@@ -20,17 +20,18 @@ GPA 3.7+ and GRE 325+
 6. University of Nottingham Ningbo China, CS undergrad, GPA 3.85
 
 ## Course Structure
-1. Course selection is relatively free (if you can't get in, ask the professor for a PTE). 2. Workload is adjustable, leaving enough time for job hunting and LeetCode grinding.
+- Course selection is relatively flexible; students can ask the instructor for a PTE when a course is full.
+- The workload can be adjusted to leave time for recruiting and technical interview preparation.
 
 The program requires 8 courses: 2 core technical courses, 3 elective technical courses, 3 professional development courses, and a capstone project. You can only choose from a given list, and selection restrictions are quite numerous -- many interesting courses are off-limits (you can pay extra to take them, but they won't count toward graduation requirements). For the mainstream Data Science and AI tracks, courses are mainly data science and machine learning content -- some even quite theoretical -- with no systems or programming courses. If you want to transition to SDE, this program may not be recommended, since there's little opportunity to take foundational CS courses.
 
-Professional development courses cover soft skills like communication, project management, and finance, as well as data analysis and decision-making courses. While these courses don't directly help with job hunting, they can improve your presentation skills. Reportedly many of them grade leniently, making them easy to coast through.
+Professional development courses cover communication, project management, finance, data analysis, and decision-making. They are less technical than the core curriculum but can help students strengthen presentation and collaboration skills. Students generally report manageable workloads in these courses.
 
 The program has no thesis requirement but requires a capstone project during the summer, typically in collaboration with a company that provides the topic. It can be done remotely -- you can work on it while doing your internship, with a final presentation at the end. However, partner companies are mainly local businesses with few major tech companies, so hoping to build big tech connections through the capstone may not be realistic.
 
-## Job Outcomes & Data Points
+## Career Outcomes
 
-For job hunting, the school's career fair is mediocre -- the attending companies are mostly unheard of. The program's career counselor regularly sends job descriptions, but the quality isn't great -- you're better off browsing LinkedIn or Glassdoor yourself. So overall, job hunting is entirely self-driven, and the program provides little help.
+Students report that the school career fair and program-level job postings provide limited access to major technology employers. Most candidates therefore rely on independent recruiting through company career pages, referrals, LinkedIn, and other external platforms.
 
 CPT/OPT support is decent. The program is STEM-designated, and CPT applications require completing one academic year (Fall, Winter, Spring).
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/intro.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/intro.mdx
@@ -1,6 +1,6 @@
 ---
 id: intro
-title: intro
+title: CS Grad Program Guide
 slug: /
 ---
 
@@ -11,56 +11,44 @@ import VisitorGeoMap from '@site/src/components/VisitorGeoMap';
 ![License: CC BY-NC-SA 4.0](https://img.shields.io/badge/License-CC%20BY--NC--SA%204.0-lightgrey.svg)
 [![GitHub Repo stars](https://img.shields.io/github/stars/csms-apply/csgrad)](https://github.com/csms-apply/csgrad)
 
-The CS Grad project focuses on North American MSCS applications, covering introductions to related programs in CS, DS, EE, ECE, IS, and more. Our motivation is to help applicants from **mainland China** and **US undergrad** backgrounds more efficiently understand each program's positioning and its **real-world value**. Unlike Open CS App, which emphasizes admission bar rankings, CS Grad focuses more on the **actual value of programs**, especially their impact on **SDE job hunting** in North America, rather than **admission difficulty alone**.
+CS Grad is an independent guide to North American master's programs in computer science and related fields, including DS, EE, ECE, and IS. It is written for applicants from both Chinese and North American universities and focuses on what each program is actually like: curriculum, cost, flexibility, admissions patterns, and career outcomes.
 
-Additionally, to help applicants evaluate programs more comprehensively, we have introduced **admission data points (admission DP)** and **job data points (job DP)** to intuitively showcase each program's admission trends and job market performance. After all, most people choose to pursue an MSCS in the US ultimately to land a job, so job data points are a critical factor in the application process that should not be overlooked.
+Instead of ranking programs only by selectivity, CS Grad combines program research with historical admissions data and employment outcomes. The goal is to help you choose programs that fit your background and long-term plans—not simply the programs that are hardest to enter.
+
+**Start here:** choose a program tier from the sidebar, [explore admissions data](/en/datapoints), or [build your application list](/en/tracker).
 
 ## Why Apply to North American MSCS Programs?
-The main reason is to land a job in the US. The US tech industry is the largest tech market in the world — Google, Meta, Apple, Amazon, Netflix, Microsoft, Nvidia..., and hedge funds
-like Two Sigma, Citadel Securities, DE Shaw, Millennium, etc. Tech new grad starting salaries are around $200K, hedge fund SWE starting salaries are $350K+, and some QR roles can reach $500K+.
-At the same time, the US job market offers better WLB. Although some companies (like Meta) can be intense, compared to ByteDance's Beijing Dazhongsi office (lights on until 10 PM), it's still much more manageable. So the common path to working in the US
-is to apply for an MSCS, do a summer internship, aim for a return offer, or find a new grad position.
+For many international applicants, a North American master's degree provides access to advanced coursework, research, professional networks, and the US technology job market. A common path is to complete an internship during the program and then pursue either a return offer or a new-grad role. Outcomes vary substantially by program and by individual preparation, which is why CS Grad evaluates academic quality and career support together.
 
 ## Join the Discord Community
 
 [Join the CS Grad Discord community](https://discord.gg/g9x4WCX2xz)
 
-## Join the QQ Group for Discussion
-QQ group number: 1039432843
+## Chinese-language QQ Community
+For applicants who prefer discussing applications in Chinese, the QQ group number is **1039432843**.
 
 ![QQ Group](/img/en/csgradqqchat.svg)
 
 
 ## Differences Between CS Grad and Open CS
 
-As mentioned above, Open CS primarily ranks programs based on **admission bars**, especially for **applicants from mainland China**, but this may not accurately reflect a program's **actual value**. Some programs are friendlier to **US undergrad** applicants but less so to **mainland China undergrad** applicants (e.g., NWU MSCS and UIUC MCS). Meanwhile, some programs have a low admission bar,
-but offer excellent career outcomes (e.g., UW EE PMP). The CS Grad project focuses on the **actual value of programs**, helping applicants evaluate school selection strategies more rationally.
+Open CS primarily organizes programs by admissions selectivity, especially for applicants from mainland China. CS Grad uses a different lens: a program's academic experience, cost, flexibility, and career outcomes. Admissions patterns can also differ between applicants educated in China and those educated in North America. A less selective program may still offer strong outcomes, while a highly selective program may not be the best fit for every applicant.
 
 Based on this motivation, I developed the CS Grad project, hoping to provide everyone with more practical application and school selection guidance.
 
 ## Program Tier Calculation Method
-Program tiers were determined through discussions among several core contributors in the early stages. Specifically, the core factors considered include:
-overall school ranking + program ranking,
-job hunting data for the major (job data and data points have been partially included in the main content),
-PhD transfer/pursuit opportunities (e.g., Brown ScMCS is well-suited for PhD-track students),
-quality of life (e.g., UCSD offers an excellent living experience),
-financial considerations (e.g., Gatech MSCS is very budget-friendly),
-geographic location (e.g., Columbia and NYU in New York have excellent locations),
-graduation flexibility (e.g., UT ECE offers very flexible graduation options),
-course rigor (e.g., CMU MCDS and MSIN courses are very systems-oriented and rigorous),
-and whether TA/RA opportunities are friendly to MS students. **Again, these program tiers were determined through discussions among myself and several early core
-contributors, so there will inevitably be some bias. PRs to suggest corrections are welcome.**
+The tiers reflect discussions among the project's early contributors. Factors include university and program reputation, curriculum and rigor, employment outcomes, PhD preparation, cost, location, quality of life, graduation flexibility, and access to TA or RA opportunities. These rankings necessarily involve judgment and may not match every applicant's priorities. Corrections and well-supported pull requests are welcome.
 
 ## North American MSCS Application Timeline
-If you are applying for Fall 2026 MSCS programs, the approximate timeline is as follows:
+If you are applying for Fall 2027 programs, the approximate timeline is as follows:
 
 ![](/img/en/applytimeline.svg)
 
-## The Zen of CS School Selection
+## Principles for Choosing a CS Program
 
-1. A person is the sum of their past experiences. No single program can completely change your life — what truly makes a difference is continually striving upward and actively seeking growth.
-2. The more important a life decision is, the less you need to follow others' guidance or over-analyze. Instead, patiently listen to your inner intuition. Trust your instincts for the big picture; rely on rational thinking for the specifics.
-3. A program with a higher admission bar is not necessarily the best fit for you.
-4. Graduate school is just a means to achieve your life goals. It is not a safe harbor, and life will not forever stand still on the day you receive your offer.
+1. No single program will determine your future; what you do during and after the program matters more.
+2. Use evidence for the details, but keep your own goals and preferences at the center of the decision.
+3. A more selective program is not automatically a better fit.
+4. Graduate school is a tool for reaching your goals, not the goal itself.
 
 <VisitorGeoMap />

--- a/i18n/en/docusaurus-plugin-content-docs/current/找我辅导.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/找我辅导.md
@@ -1,3 +1,8 @@
+---
+title: Work with the CS Grad Author
+slug: /consulting
+---
+
 # Consulting Services
 
 # About Me

--- a/i18n/en/docusaurus-plugin-content-docs/current/转码项目.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/转码项目.md
@@ -26,10 +26,10 @@ they can refer to [Prerequisite Courses for Career Switchers](useful_docs/转码
 
 
 ## Requires Some Prerequisite Courses
-1. [Duke ECE](B+/duke%20ece.md)
+1. [Duke ECE](A-/duke%20ece.md)
 2. Duke Game Design
 3. [Columbia MSCS](A/columbia%20mscs.md)
-4. [Columbia EE](A-/Columbia%20ee.md)
+4. [Columbia EE](B+/Columbia%20ee.md)
 5. [CMU MSIN](S/cmu%20msin.md) (there are past data points of students with 5-year Clinical Medicine undergrad degrees who completed prerequisites and switched to CS, as well as many EE/IS/Cybersecurity students who were admitted)
 6. [CMU MISM](B+/cmu%20mism.md)
 7. [Emory MSCS](B/Emory%20MSCS.md)
@@ -37,5 +37,5 @@ they can refer to [Prerequisite Courses for Career Switchers](useful_docs/转码
 9. [Gatech CSE](A+/Gatech%20CSE.md) (you can first apply to a less competitive track, such as ISyE, then transfer to MSCS after enrollment)
 10. [UIUC ECE](B/UIUC%20ECE%20MENG.md)
 11. [UW EE PMP](A/uw%20ee%20pmp.md)
-12. [NCSU MCS](B-/NCSU%20MCS.md)
+12. [NCSU MCS](B/NCSU%20MCS.md)
 13. [NEU IS](B-/NEU%20IS.md)

--- a/i18n/en/docusaurus-plugin-content-docs/current/转码项目.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/转码项目.md
@@ -1,3 +1,8 @@
+---
+title: Career Change Programs
+slug: /career-change-programs
+---
+
 # Career Switcher Programs
 
 Career switcher programs are divided into completely zero-background programs (no CS prerequisite courses taken at all) and partially zero-background programs (some CS prerequisite courses taken). If a student is from an economics/business/biology background and has not taken prerequisite courses such as Data Structures, Computer Organization, Operating Systems, etc.,

--- a/i18n/en/docusaurus-theme-classic/footer.json
+++ b/i18n/en/docusaurus-theme-classic/footer.json
@@ -1,38 +1,38 @@
 {
-  "link.title.Docs": {
-    "message": "Docs",
-    "description": "The title of the footer links column with title=Docs in the footer"
+  "link.title.Explore": {
+    "message": "Explore",
+    "description": "The title of the footer links column with title=Explore in the footer"
   },
   "link.title.Community": {
     "message": "Community",
     "description": "The title of the footer links column with title=Community in the footer"
   },
-  "link.title.More": {
-    "message": "More",
-    "description": "The title of the footer links column with title=More in the footer"
+  "link.title.Project": {
+    "message": "Project",
+    "description": "The title of the footer links column with title=Project in the footer"
   },
-  "link.item.label.Tutorial": {
-    "message": "Tutorial",
-    "description": "The label of footer link with label=Tutorial linking to docs/intro"
+  "link.item.label.Program Guide": {
+    "message": "Program Guide",
+    "description": "The label of the footer link to the program guide"
   },
-  "link.item.label.Stack Overflow": {
-    "message": "Stack Overflow",
-    "description": "The label of footer link with label=Stack Overflow linking to https://stackoverflow.com/questions/tagged/docusaurus"
+  "link.item.label.Data Points": {
+    "message": "Data Points",
+    "description": "The label of the footer link to admissions data"
   },
-  "link.item.label.Discord": {
-    "message": "Discord",
-    "description": "The label of footer link with label=Discord linking to https://discordapp.com/invite/docusaurus"
+  "link.item.label.Application Tracker": {
+    "message": "Application Tracker",
+    "description": "The label of the footer link to the application tracker"
   },
-  "link.item.label.X": {
-    "message": "X",
-    "description": "The label of footer link with label=X linking to https://x.com/docusaurus"
+  "link.item.label.CS Grad Discord": {
+    "message": "CS Grad Discord",
+    "description": "The label of the footer link to the CS Grad Discord community"
   },
   "link.item.label.GitHub": {
     "message": "GitHub",
     "description": "The label of footer link with label=GitHub linking to https://github.com/csms-apply/csms-apply.github.io"
   },
   "copyright": {
-    "message": "Copyright © 2026 红尘客栈_",
+    "message": "Copyright © 2026 CS Grad",
     "description": "The footer copyright"
   }
 }

--- a/i18n/en/docusaurus-theme-classic/navbar.json
+++ b/i18n/en/docusaurus-theme-classic/navbar.json
@@ -12,7 +12,7 @@
     "description": "Navbar item with label 项目介绍"
   },
   "item.label.DataPoints": {
-    "message": "DataPoints",
+    "message": "Data Points",
     "description": "Navbar item with label DataPoints"
   },
   "item.label.申请跟踪": {

--- a/src/pages/datapoints.jsx
+++ b/src/pages/datapoints.jsx
@@ -202,6 +202,15 @@ const COPY = {
     cardLabelInternship: 'Internship',
     cardLabelPub: 'Pub',
     cardLabelNotes: 'Notes',
+    notesLabel: {
+      dp: 'Application notes',
+      research: 'Research',
+      internship: 'Internships',
+      pub: 'Publications',
+      rec: 'Recommendations',
+      soft: 'Additional background',
+      education: 'Education',
+    },
   },
 };
 

--- a/src/pages/datapoints.jsx
+++ b/src/pages/datapoints.jsx
@@ -115,6 +115,8 @@ const COPY = {
     cardLabelInternship: '实习',
     cardLabelPub: '论文',
     cardLabelNotes: '备注',
+    resultLabels: {},
+    ugCategoryLabels: {},
   },
   en: {
     pageTitle: 'DataPoints',
@@ -123,7 +125,7 @@ const COPY = {
     metaApplicants: 'applicants',
     metaPrograms: 'programs',
     metaDatapoints: 'datapoints',
-    dataNote: 'Note: data comes from a historical Seatable archive. Personally identifying fields (contacts / private notes / reference details) have been redacted.',
+    dataNote: 'Note: data comes from a historical Seatable archive. Personally identifying fields have been redacted; institution names and free-text notes remain in the language in which they were submitted.',
     loadingData: 'Loading DataPoints…',
     loadFail: 'Failed to load data: ',
     searchPlaceholder: 'Search school / program',
@@ -202,6 +204,31 @@ const COPY = {
     cardLabelInternship: 'Internship',
     cardLabelPub: 'Pub',
     cardLabelNotes: 'Notes',
+    resultLabels: {
+      '默拒': 'Implicit reject',
+    },
+    ugCategoryLabels: {
+      '清北': 'Tsinghua / Peking',
+      '华五': 'C9 university',
+      '国科/上科/南科': 'UCAS / ShanghaiTech / SUSTech',
+      '10043': 'Top Chinese university (10043)',
+      '985': 'Project 985 university',
+      '211': 'Project 211 university',
+      '双非': 'Other mainland university',
+      '陆本': 'Mainland China university',
+      '陆本中外合办': 'Sino-foreign joint program',
+      '中外合办': 'Sino-foreign joint program',
+      '中外合办校（XJTLU等）': 'Sino-foreign joint university (for example, XJTLU)',
+      '陆本中外合办院系（JI/ZJUI等）': 'Sino-foreign joint institute (for example, JI/ZJUI)',
+      '美本': 'US university',
+      '加本': 'Canadian university',
+      '英本': 'UK university',
+      '澳本': 'Australian university',
+      '港本': 'Hong Kong university',
+      '坡本': 'Singapore university',
+      '欧陆本': 'Continental European university',
+      '海本': 'Overseas university',
+    },
     notesLabel: {
       dp: 'Application notes',
       research: 'Research',
@@ -429,8 +456,8 @@ function Table({ counts, filterOpts, me, meChecked, t }) {
     if (school) items.push({ key: 'school', label: t.filterSchool, value: school });
     if (tier) items.push({ key: 'tier', label: t.filterTier, value: tier });
     if (year) items.push({ key: 'year', label: t.filterYear, value: year });
-    if (result) items.push({ key: 'result', label: t.filterResult, value: result });
-    if (ugCat) items.push({ key: 'ugCat', label: t.filterUgCat, value: ugCat });
+    if (result) items.push({ key: 'result', label: t.filterResult, value: displayDataValue(result, t.resultLabels) });
+    if (ugCat) items.push({ key: 'ugCat', label: t.filterUgCat, value: displayDataValue(ugCat, t.ugCategoryLabels) });
     if (major) items.push({ key: 'major', label: t.filterMajor, value: major });
     if (gpaRange.valid && (gpaRange.min != null || gpaRange.max != null)) {
       items.push({ key: 'gpa', label: t.gpaRangeLabel, value: formatGpaRange(gpaRange.min, gpaRange.max) });
@@ -468,8 +495,8 @@ function Table({ counts, filterOpts, me, meChecked, t }) {
         <Select label={t.filterSchool} value={school} onChange={setSchool} options={filterOpts.schools} allText={t.filterAll} />
         <Select label={t.filterTier} value={tier} onChange={setTier} options={filterOpts.tiers} allText={t.filterAll} />
         <Select label={t.filterYear} value={year} onChange={setYear} options={filterOpts.years} allText={t.filterAll} />
-        <Select label={t.filterResult} value={result} onChange={setResult} options={RESULT_OPTIONS} allText={t.filterAll} />
-        <Select label={t.filterUgCat} value={ugCat} onChange={setUgCat} options={filterOpts.ugCats} allText={t.filterAll} />
+        <Select label={t.filterResult} value={result} onChange={setResult} options={RESULT_OPTIONS} allText={t.filterAll} formatOption={(value) => displayDataValue(value, t.resultLabels)} />
+        <Select label={t.filterUgCat} value={ugCat} onChange={setUgCat} options={filterOpts.ugCats} allText={t.filterAll} formatOption={(value) => displayDataValue(value, t.ugCategoryLabels)} />
         <Select label={t.filterMajor} value={major} onChange={setMajor} options={filterOpts.majors} allText={t.filterAll} />
         <GpaRangeFilter
           min={gpaMin}
@@ -627,7 +654,7 @@ function DesktopTable({ rows, t, onRowClick }) {
               <td>
                 {a.ug_school_category ? (
                   <span className={`${styles.ugCatBadge} ${ugCatBadgeClass(a.ug_school_category)}`}>
-                    {a.ug_school_category}
+                    {displayDataValue(a.ug_school_category, t.ugCategoryLabels)}
                   </span>
                 ) : <span className={styles.muted}>—</span>}
               </td>
@@ -811,7 +838,7 @@ function MobileCards({ rows, t, onCardClick }) {
             <span style={{ textAlign: 'right' }}>
               {a.ug_school_category ? (
                 <span className={`${styles.ugCatBadge} ${ugCatBadgeClass(a.ug_school_category)}`} style={{ marginRight: 4 }}>
-                  {a.ug_school_category}
+                  {displayDataValue(a.ug_school_category, t.ugCategoryLabels)}
                 </span>
               ) : null}
               {a.ug_school_name || ''}
@@ -861,7 +888,7 @@ function MobileCards({ rows, t, onCardClick }) {
 function ResultPills({ d, t }) {
   return (
     <>
-      <span className={`${styles.pill} ${pillClass(d.result)}`}>{d.result || '—'}</span>
+      <span className={`${styles.pill} ${pillClass(d.result)}`}>{displayDataValue(d.result, t.resultLabels) || '—'}</span>
       {d.is_funded ? (
         <span className={styles.fundBadge} role="img" aria-label={t.funded} title={t.funded}>{t.badgeFunded}</span>
       ) : null}
@@ -882,14 +909,18 @@ function GpaCell({ a }) {
   );
 }
 
-function Select({ label, value, onChange, options, allText }) {
+function displayDataValue(value, labels) {
+  return labels?.[value] || value;
+}
+
+function Select({ label, value, onChange, options, allText, formatOption = (option) => option }) {
   return (
     <label className={styles.selectWrap}>
       <span>{label}</span>
       <select value={value} onChange={(e) => onChange(e.target.value)} aria-label={label}>
         <option value="">{allText}</option>
         {options.map((o) => (
-          <option key={o} value={o}>{o}</option>
+          <option key={o} value={o}>{formatOption(o)}</option>
         ))}
       </select>
     </label>

--- a/src/pages/tracker.jsx
+++ b/src/pages/tracker.jsx
@@ -239,9 +239,11 @@ function KanbanColumn({ column, cards, onAddCard, onEditCard, onDeleteCard }) {
       <div className={styles.columnHeader}>
         <h3 className={styles.columnTitle}>
           {column.title}
-          <span style={{ fontWeight: 400, fontSize: '0.75rem', marginLeft: 6, opacity: 0.7 }}>
-            {column.subtitle}
-          </span>
+          {column.title !== column.subtitle && (
+            <span style={{ fontWeight: 400, fontSize: '0.75rem', marginLeft: 6, opacity: 0.8 }}>
+              {column.subtitle}
+            </span>
+          )}
         </h3>
         <span className={styles.columnCount}>{cards.length}</span>
       </div>
@@ -351,7 +353,7 @@ function CardModal({ card, columns, essayStatuses, onSave, onClose }) {
               >
                 {columns.map((c) => (
                   <option key={c.id} value={c.id}>
-                    {c.title} ({c.subtitle})
+                    {c.title}{c.title !== c.subtitle ? ` (${c.subtitle})` : ''}
                   </option>
                 ))}
               </select>

--- a/src/pages/tracker.module.css
+++ b/src/pages/tracker.module.css
@@ -257,7 +257,7 @@
 .colReach .columnCount { background: #c97a3a; color: #fff; }
 
 .colMatch .columnHeader { background: #fdf2d0; }
-.colMatch .columnTitle { color: #b8985d; }
+.colMatch .columnTitle { color: #806529; }
 .colMatch .columnCount { background: #b8985d; color: #fff; }
 
 .colTarget .columnHeader { background: #d4eae7; }
@@ -288,7 +288,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  color: #baa88a;
+  color: #76664f;
   font-size: 0.82rem;
   font-style: italic;
   padding: 40px 16px;
@@ -485,7 +485,7 @@
   border: 2px dashed #d9c9a8;
   border-radius: 12px;
   background: none;
-  color: #baa88a;
+  color: #76664f;
   font-size: 0.82rem;
   cursor: pointer;
   transition: all 0.15s;
@@ -971,7 +971,7 @@
 
 .topBarLink {
   font-size: 0.82rem;
-  color: #c9a96e;
+  color: #80652e;
   text-decoration: none;
   cursor: pointer;
 }

--- a/src/theme/DocItem/index.js
+++ b/src/theme/DocItem/index.js
@@ -1,9 +1,11 @@
 import React, { useEffect } from "react";
 import DocItem from "@theme-original/DocItem";
 import { useColorMode } from "@docusaurus/theme-common";
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 
 export default function DocItemWrapper(props) {
   const { colorMode } = useColorMode();
+  const { i18n } = useDocusaurusContext();
 
   useEffect(() => {
 
@@ -23,7 +25,7 @@ export default function DocItemWrapper(props) {
     script.setAttribute("data-emit-metadata", "0");
     script.setAttribute("data-input-position", "top");
     script.setAttribute("data-theme", colorMode === "dark" ? "dark" : "light");
-    script.setAttribute("data-lang", "zh-CN");
+    script.setAttribute("data-lang", i18n.currentLocale === "en" ? "en" : "zh-CN");
     script.setAttribute("crossorigin", "anonymous");
     script.async = true;
 
@@ -36,7 +38,7 @@ export default function DocItemWrapper(props) {
     if (markdownEl) {
       markdownEl.insertAdjacentElement("afterend", container);
     }
-  }, [colorMode]);
+  }, [colorMode, i18n.currentLocale]);
 
   return <DocItem {...props} />;
 }

--- a/static/img/en/applytimeline.svg
+++ b/static/img/en/applytimeline.svg
@@ -7,10 +7,10 @@
     <text x="625" y="55" font-size="31">Internships / Research</text>
     <text x="905" y="55" font-size="31">Recommendation Letters</text>
     <text x="1160" y="55" font-size="31">Applications</text>
-    <text x="119" y="207" font-size="38">Jan 2025</text>
-    <text x="498" y="207" font-size="38">May 2025</text>
+    <text x="119" y="207" font-size="38">Jan 2026</text>
+    <text x="498" y="207" font-size="38">May 2026</text>
     <text x="690" y="207" font-size="38">Sep</text>
     <text x="862" y="207" font-size="38">Oct</text>
-    <text x="1092" y="207" font-size="38">Jan 2026</text>
+    <text x="1092" y="207" font-size="38">Jan 2027</text>
   </g>
 </svg>


### PR DESCRIPTION
## Summary
- fix the English Data Points crash and translate controlled admissions-data labels
- remove duplicated Tracker column labels and improve low-contrast controls
- localize the English sidebar, Giscus comments, metadata, footer, and public routes
- rewrite awkward homepage/UCLA copy and update the Fall 2027 timeline
- repair three broken career-switcher program links

## Validation
- `npm run test:gpa-filter`
- `npm run test:migration`
- `npm run build` (zh-Hans and en, no broken-link warnings)
- browser regression on `/en/`, `/en/datapoints`, and `/en/tracker`

## Review notes
Please review before merge. This PR is intentionally not merged.