### PR TITLE
Fix English community section and timeline images

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/intro.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/intro.mdx
@@ -24,12 +24,6 @@ For many international applicants, a North American master's degree provides acc
 
 [Join the CS Grad Discord community](https://discord.gg/g9x4WCX2xz)
 
-## Chinese-language QQ Community
-For applicants who prefer discussing applications in Chinese, the QQ group number is **1039432843**.
-
-![QQ Group](/img/en/csgradqqchat.svg)
-
-
 ## Differences Between CS Grad and Open CS
 
 Open CS primarily organizes programs by admissions selectivity, especially for applicants from mainland China. CS Grad uses a different lens: a program's academic experience, cost, flexibility, and career outcomes. Admissions patterns can also differ between applicants educated in China and those educated in North America. A less selective program may still offer strong outcomes, while a highly selective program may not be the best fit for every applicant.
@@ -43,8 +37,8 @@ The tiers reflect discussions among the project's early contributors. Factors in
 If you are applying for Fall 2027 programs, the approximate timeline is as follows:
 
 <picture>
-  <source media="(max-width: 700px)" srcSet="/en/img/en/applytimeline-mobile.svg" />
-  <img src="/en/img/en/applytimeline.svg" alt="Fall 2027 graduate application timeline" />
+  <source media="(max-width: 700px)" srcSet="/img/en/applytimeline-mobile.svg" />
+  <img src="/img/en/applytimeline.svg" alt="Fall 2027 graduate application timeline" />
 </picture>
 
 ## Principles for Choosing a CS Program

--- a/static/img/en/csgradqqchat.svg
+++ b/static/img/en/csgradqqchat.svg
@@ -1,9 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="600" height="1301" viewBox="0 0 600 1301">
-  <image href="../csgradqqchat.png" width="600" height="1301"/>
-  <rect x="55" y="205" width="490" height="155" rx="14" fill="#25282b"/>
-  <text x="300" y="270" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="34" text-anchor="middle">CS Grad Community</text>
-  <text x="300" y="318" fill="#aeb3b7" font-family="Arial, Helvetica, sans-serif" font-size="24" text-anchor="middle">QQ Group: 1039432843</text>
-  <rect x="75" y="953" width="450" height="100" fill="#101315"/>
-  <text x="300" y="1012" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="25" text-anchor="middle">Scan the QR code to join the group</text>
-  <rect x="80" y="1080" width="440" height="190" fill="#101315"/>
-</svg>


### PR DESCRIPTION
## Summary
- remove the QQ community section from the English homepage
- keep Discord as the only English community link
- remove the unused English QQ image wrapper
- fix duplicated locale prefixes in English application timeline image paths

## Verification
- 
> csgrad@0.0.0 build
> docusaurus build --locale en


 ------------------------------------------------------------------------------                                                                                                         Update available 3.7.0 → 3.10.2                                                                                                                 To upgrade Docusaurus packages with the latest version, run the                                       following command:                                                        `npm i @docusaurus/core@latest                                            @docusaurus/plugin-client-redirects@latest                        @docusaurus/plugin-google-gtag@latest @docusaurus/preset-classic@latest            @docusaurus/module-type-aliases@latest @docusaurus/types@latest`                                                                                          ------------------------------------------------------------------------------ 

[INFO] [en] Creating an optimized production build...
[webpackbar] ℹ Compiling Client
[webpackbar] ℹ Compiling Server
[webpackbar] ✔ Server: Compiled successfully in 926.34ms
[webpackbar] ✔ Client: Compiled successfully in 1.08s
[SUCCESS] Generated static files in "build".
[INFO] Use `npm run serve` command to test your build locally.
- confirmed generated homepage contains Discord but no QQ section
- confirmed desktop and mobile timeline assets are present in the build