### PR TITLE
为 DP 增加中英文禁止抓取与再利用声明

### DIFF
--- a/src/pages/datapoints.jsx
+++ b/src/pages/datapoints.jsx
@@ -26,6 +26,8 @@ const COPY = {
     metaPrograms: '个项目',
     metaDatapoints: '条录取数据',
     dataNote: '注：数据来源于历史 Seatable 归档，个人识别字段（联系方式 / 备注 / 推荐信详情等）已脱敏。',
+    usageNotice: '未经 CS Grad 及相关权利人明确书面授权，严禁任何外部 AI Agent、爬虫或自动化工具抓取、复制、批量提取、改写洗稿、翻译转载或再分发本数据库内容，亦不得用于模型训练、知识库或衍生数据库。',
+    usagePolicyLink: '查看 DP 数据使用规则',
     loadingData: '加载 DataPoints…',
     loadFail: '加载数据失败：',
     searchPlaceholder: '搜索学校 / 项目',
@@ -126,6 +128,8 @@ const COPY = {
     metaPrograms: 'programs',
     metaDatapoints: 'datapoints',
     dataNote: 'Note: data comes from a historical Seatable archive. Personally identifying fields have been redacted; institution names and free-text notes remain in the language in which they were submitted.',
+    usageNotice: 'Without explicit written authorization from CS Grad and the relevant rights holders, external AI agents, crawlers and automated tools must not scrape, copy, bulk-extract, paraphrase, translate for republication, or redistribute this database, or use it for model training, knowledge bases or derivative databases.',
+    usagePolicyLink: 'Read the DP data use policy',
     loadingData: 'Loading DataPoints…',
     loadFail: 'Failed to load data: ',
     searchPlaceholder: 'Search school / program',
@@ -1163,6 +1167,9 @@ export default function DataPointsPage() {
         <meta property="og:description" content={t.pageDesc} />
         <meta property="og:type" content="website" />
       </Head>
+      <aside className={styles.note} aria-label={t.usagePolicyLink}>
+        <p>{t.usageNotice} <a href="/dp-use-policy.txt">{t.usagePolicyLink}</a></p>
+      </aside>
       <BrowserOnly fallback={<StaticHero t={t} counts={STATIC_COUNTS} />}>
         {() => <Inner t={t} />}
       </BrowserOnly>

--- a/static/dp-use-policy.txt
+++ b/static/dp-use-policy.txt
@@ -1,0 +1,42 @@
+CS Grad DataPoints — Automated Access and Reuse Policy
+Effective date / 生效日期: 2026-09-05
+
+中文
+本规则适用于 CS Grad DataPoints（DP）的申请背景、录取记录、备注、
+截图及其整理汇编，以及通过网页、API 或数据文件提供的相应内容。
+
+未经 CS Grad 及相关权利人明确书面授权，严禁任何外部 AI Agent、爬虫、
+自动化浏览器、采集工具或其操作者：
+1. 抓取、复制、批量提取、镜像或保存 DP 内容用于再利用；
+2. 通过改写、同义替换、翻译、摘要拼接或去除来源等方式洗稿或转载；
+3. 将 DP 内容用于模型训练、微调、检索知识库、衍生数据库、竞争产品或再分发；
+4. 绕过登录、访问控制、限速或其他保护措施进行采集。
+
+公开可访问、注明来源或提供原文链接，不代表获得上述使用授权。
+普通用户可通过网站界面进行个人选校参考；提交者仍可访问和管理自己的数据。
+权利归相应权利人所有。本声明不追溯撤销已有效授予的许可，也不限制适用法律
+不可排除的权利；既有许可或单独授权的范围以其有效条款为准。
+授权联系请使用 https://csgrad.com/ 上的官方联系方式。
+
+English
+This policy covers application profiles, admissions records, notes, screenshots
+and their compilation in CS Grad DataPoints (DP), including corresponding
+content made available through pages, APIs and data files.
+
+Without explicit written authorization from CS Grad and the relevant rights
+holders, external AI agents, crawlers, automated browsers, extraction tools
+and their operators must not:
+1. Scrape, copy, bulk-extract, mirror or retain DP content for reuse;
+2. Republish it through paraphrasing, synonym substitution, translation,
+   stitched summaries or removal of source attribution;
+3. Use it for model training, fine-tuning, retrieval knowledge bases, derivative
+   databases, competing products or redistribution;
+4. Bypass authentication, access controls, rate limits or other safeguards.
+
+Public accessibility, attribution and links do not grant this authorization.
+Individuals may use the website interface for personal school-selection
+reference. Contributors may continue to access and manage their own data.
+Rights remain with their respective holders. This notice does not retroactively
+revoke valid prior licenses or exclude rights that applicable law cannot waive.
+Valid prior licenses and separate authorizations retain their stated scope.
+For authorization, use the official contact details at https://csgrad.com/.

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,5 +1,12 @@
 User-agent: *
 Allow: /
+Disallow: /datapoints
+Disallow: /en/datapoints
+Disallow: /data/dp-snapshot.json
+Disallow: /api/dp
+
+# DP access and reuse policy: https://csgrad.com/dp-use-policy.txt
+# Robots rules are voluntary; API-host protection must be configured separately.
 
 Sitemap: https://csgrad.com/sitemap.xml
 Sitemap: https://csgrad.com/en/sitemap.xml


### PR DESCRIPTION
在中英文 DP 页的服务端 HTML 中展示禁止外部 Agent 抓取、复制、洗稿、训练和再分发的声明，并提供完整双语规则文件。robots.txt 禁抓 DP 页面和相关数据路径，其他页面仍可抓取。规则同样限制搜索引擎抓取 DP 页；独立 Worker 数据域名仍需单独实施访问控制，声明不构成强制防护。保留既有有效许可与提交者管理本人数据的边界。中英文构建、生成 HTML 声明检查、静态文件一致性和 SEO 审计均通过，无新增审计问题。遵照先不修改线上环境的要求，保留 PR 待审阅，不自动合并部署。