### PR TITLE
修正首页引导文案和中英文导航名称

### DIFF
--- a/docs/intro.mdx
+++ b/docs/intro.mdx
@@ -25,7 +25,7 @@ import Head from '@docusaurus/Head';
 
 CS Grad 帮助中国大陆和北美本科申请者了解北美计算机及相关硕士项目。你可以查看项目介绍、参考历史录取数据，并结合自己的背景、课程偏好、预算和职业目标制定申请计划。
 
-**从这里开始：**浏览侧栏项目介绍、[查询录取数据](/datapoints)、[整理申请清单](/tracker)，或[了解申请辅导](/找我辅导)。
+<strong>从这里开始：</strong>浏览侧栏项目介绍、[查询录取数据](/datapoints)、[整理申请清单](/tracker)，或[了解申请辅导](/找我辅导)。
 
 <p><a href="https://csgrad.com/en/" hrefLang="en" lang="en">English version</a></p>
 

--- a/i18n/en/docusaurus-plugin-content-docs/current.json
+++ b/i18n/en/docusaurus-plugin-content-docs/current.json
@@ -47,9 +47,9 @@
     "message": "Useful Docs",
     "description": "The label for category 有用的文档 in sidebar tutorialSidebar"
   },
-  "sidebar.tutorialSidebar.doc.intro": {
-    "message": "Introduction",
-    "description": "The label for the doc item intro in sidebar tutorialSidebar, linking to the doc intro"
+  "sidebar.tutorialSidebar.doc.北美MSCS申请": {
+    "message": "MSCS Application Guide",
+    "description": "The label for the homepage in sidebar tutorialSidebar, linking to the doc intro"
   },
   "sidebar.tutorialSidebar.doc.转码项目合集": {
     "message": "Career Change Programs",

--- a/sidebars.js
+++ b/sidebars.js
@@ -20,7 +20,7 @@ const sidebars = {
     {
       type: 'doc',
       id: 'intro',
-      label: 'intro',
+      label: '北美MSCS申请',
     },
 
     {


### PR DESCRIPTION
上线验收发现中文首页的粗体标记直接显示星号，侧栏和面包屑仍叫 intro。改用明确的 strong 标记，并将中文首页导航命名为“北美MSCS申请”，英文同步为“MSCS Application Guide”，URL 和文档 ID 保持不变。中英文构建、生成 HTML 的粗体与面包屑检查、SEO 审计通过，无新增问题。作为 PR #299 的线上验收修正，按用户授权验证后合并发布。