### PR TITLE
修复两轮端到端发现的语言跳转、清单数据保护和 DP 体验问题

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Test GPA filtering
         run: npm run test:gpa-filter
 
+      - name: Test navigation, tracker data protection, and DP error states
+        run: npm run test:ux
+
       - name: Audit built SEO output
         run: npm run check:seo
 

--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -528,6 +528,19 @@
     "message": "Skip to main content",
     "description": "The skip to content label used for accessibility, allowing to rapidly navigate to main content with keyboard tab/enter navigation"
   },
+  "tracker.action.close": {"message": "Close"},
+  "tracker.storage.loadFailed": {"message": "The saved tracker could not be read. Its original data has been kept. Export the original backup before importing a valid backup."},
+  "tracker.storage.saveFailed": {"message": "Your browser could not save the tracker. Export a backup to avoid losing changes on refresh."},
+  "tracker.import.invalid": {"message": "Import failed: choose a complete, valid tracker JSON backup (up to 10 MB). Your current list was not changed."},
+  "tracker.import.success": {"message": "Import complete. The previous list was backed up; you can undo the latest import."},
+  "tracker.import.storageFailed": {"message": "Your browser could not save the previous backup or the new list. Import was not completed. Your current list was not changed."},
+  "tracker.import.rollbackFailed": {"message": "Import was not completed and your current list was not changed. However, your browser could not restore the previous undo backup, so undo is disabled for this session. Export your current list now; do not rely on the existing undo backup."},
+  "tracker.import.undone": {"message": "The list from before the import has been restored."},
+  "tracker.import.undo": {"message": "Undo latest import"},
+  "tracker.import.confirm": {"message": "This backup contains {count} programs and will replace your current {current} programs (not merge them). Your current list will be backed up for undo, replacing the previous import backup. Continue?"},
+  "tracker.import.replace": {"message": "Confirm replacement"},
+  "tracker.import.undoConfirm": {"message": "Restore the list from before your latest import? Edits made after importing will be replaced. Export your current list first if you want to keep those edits."},
+  "tracker.import.restore": {"message": "Restore previous list"},
   "theme.tags.tagsPageTitle": {
     "message": "Tags",
     "description": "The title of the tag list page"

--- a/i18n/en/docusaurus-plugin-content-docs/current/找我辅导.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/找我辅导.md
@@ -1,7 +1,8 @@
 ---
 title: US CS & MSCS Application Consulting
+sidebar_label: Application Consulting
 slug: /consulting
-description: Application consulting for US CS, MSCS, and related master's programs, covering school selection, application planning, essays, interviews, and offer evaluation.
+description: Application consulting for US CS, MSCS, and related master's programs, covering school selection, background planning, essays, online applications, interviews, and offer evaluation, with past cases and contact details.
 hide_title: true
 ---
 
@@ -9,21 +10,24 @@ hide_title: true
 
 ## About Me
 
-I am a Fall 2024 alum who received offers from CMU, Columbia, UIUC, Gatech, and other top universities during my application cycle. I had extensive internship experience during school, having interned at Microsoft, ByteDance, HP, and Baidu.
+In my Fall 2024 application cycle, I received offers from CMU, Columbia, UIUC, Gatech, and other universities. During my studies, I gained extensive internship experience at Meta, Microsoft, HP, and Baidu.
 
 For Fall 2025, I mentored three students who were admitted to Cornell CS MEng, CMU SESV, and UChicago MPCS respectively.
 
-For Fall 2026, my mentees' offers so far include: Harvard CSE*1, UChicago MPCS offer\*3, CMU MSIN offer \*1, Cornell Tech CM offer\*1, CMU MISM offer\*1, UCI MSWE*1 (see Xiaohongshu for detailed offers and timeline)
+For Fall 2026, my students' offers so far include: Harvard CSE (1), UChicago MPCS (3), CMU MSIN (1), Cornell Tech CM (1), CMU MISM (1), and UCI MSWE (1). See Xiaohongshu for detailed offers and timelines.
+
+[View past students' application backgrounds and admission results →](/en/past-dp)
+
 ## Services Offered
 
-I currently focus on US CS job-oriented master's application consulting services, specifically including:
+I focus on applications to career-oriented CS master's programs in the United States. My services include:
 
 1. **School Selection & Positioning**
     I will help students with school selection and positioning, going beyond just the information on Open CS to include many strong programs that Open CS has missed. My school selection strategy is to apply broadly and leave no regrets — I recommend applying to at least 20 programs.
-2. **Soft Background Enhancement & Career Development Planning**
-    I will help students enhance their soft background and plan their career development, especially for applicants targeting the SDE track. I can also provide internal referrals — I have previously helped some students land positions (including at companies like Microsoft).
-3. **Regular Meeting Progress Updates**
-    I will hold monthly meetings with students to comprehensively track internship progress, GPA performance, paper publications, letters of recommendation preparation, and essay writing (such as SOP and PS). I will also provide targeted advice, such as research direction selection (AI or Systems), and how to more effectively request letters of recommendation from professors, to help students better plan and improve.
+2. **Profile Development & Career Planning**
+    I will help students strengthen the experience-based parts of their applications and plan their careers, especially those aiming for SDE roles. I can also provide internal referrals; I have previously referred students who went on to join companies including Microsoft.
+3. **Monthly Progress Meetings**
+    We will meet monthly to review internships, GPA, publications, recommendation letters, and essays such as the SOP and PS. I will offer specific advice on questions such as choosing an AI or systems research direction and approaching professors for recommendation letters.
 4. **Essay Brainstorming**
    - **SOP (Statement of Purpose)**
       I will analyze the student's personal characteristics and growth experiences to craft a Statement of Purpose that aligns with their individual background. I ensure the SOP is tailored to each program's preferences (e.g., CMU MSIN prefers essays about job hunting, NWU MSCS prefers essays about research).
@@ -37,14 +41,26 @@ I currently focus on US CS job-oriented master's application consulting services
     I will help students find internship opportunities, provide resume and cover letter optimization advice, and share internship application experience and tips. If a student later joins a US company (such as Microsoft, DE Shaw), I will assist with internal referrals. I will conduct mock interviews to help students improve their interview skills and build confidence for real interviews.
 6. **Program Interview Coaching**
     I will provide interview coaching for US CS program interviews, such as CMU MSIN, Columbia MSCS, etc., helping students better prepare for and handle interviews.
-7. **Offer Analysis**
+7. **Online Application Preparation & Submission Support**
+    I will help students complete and check university application forms, including education and coursework details, internship and research experience, document uploads, and version management. Students themselves must confirm and complete every final submission.
+8. **Application Progress & Timeline Management**
+    I will put together a complete application timeline and provide reminders and follow-up for deadlines, recommendation letters, additional materials, interviews, and other key steps.
+9. **Offer Analysis**
     I will help students analyze the pros and cons of their received offers and choose the most suitable program. I am committed to a long-term approach and promise to be responsible for every student I mentor.
+10. **Post-Offer Support**
+    I will help with the offer acceptance process, share experience-based guidance on deposits and the I-20, and offer suggestions for planning courses, internships, and the job search.
 
-------
+---
 
-**Service Fee**
+I will help coordinate the entire application process: managing the timeline, planning coursework, preparing recommendation letters, and handling unexpected problems such as losing contact with a recommender. Whether you need to address a low GPA, complete CS prerequisites for a career change, or aim for programs at Stanford, Harvard, CMU, and other top universities, I will develop a plan around your background and help you work through problems throughout the process.
 
-The full-service package costs **$3,500 USD** (converted to RMB at the exchange rate at the time of contract signing).
+## Service Fee
+
+Summer early-bird price: ~~$4,500 USD~~ **$3,500 USD**. The regular price of **$4,500 USD resumes on September 15, 2026**.
+
+The fee is converted to RMB at the exchange rate at the time of contract signing.
+
+**Contact**
 
 <button
   type="button"

--- a/i18n/en/docusaurus-plugin-content-docs/current/转码项目.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/转码项目.md
@@ -1,5 +1,6 @@
 ---
 title: Career Change Programs
+sidebar_label: Career Change Programs
 slug: /career-change-programs
 ---
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/过往DP.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/过往DP.mdx
@@ -1,0 +1,49 @@
+---
+title: US CS Master's Consulting Cases and Admission Results
+slug: /past-dp
+description: Explore selected past students' application backgrounds and admission results, including Harvard CSE, CMU MSIN, Cornell MEng CS, and UChicago CS.
+---
+
+These selected cases show past students' actual graduate admissions and employment outcomes. Names, contact details, and other identifying information have been hidden in the screenshots to protect students' privacy.
+
+The original screenshots are preserved below and contain Chinese text; the case summaries are provided in English.
+
+## Case 1: Math and CS at a Top 40 US University — Admitted to Harvard CSE
+
+GPA 3.9+, no internship experience, and research experience with results to show for it.
+
+<img src="/img/dp-cases/harvard-cse.png" alt="Original Chinese screenshot of a Math and CS student from a Top 40 US university admitted to Harvard CSE" style={{display: 'block', width: '90%', height: 'auto', margin: '0 auto'}} />
+
+## Case 2: NYU Undergraduate — Admitted to CMU MSIN
+
+GPA 3.6, internship experience, and no research output.
+
+<img src="/img/dp-cases/nyu-cmu-msin-01.png" alt="First original Chinese conversation screenshot of an NYU undergraduate admitted to CMU MSIN" style={{display: 'block', width: '90%', height: 'auto', margin: '0 auto'}} />
+
+## Case 2, Continued: NYU Undergraduate — Admitted to CMU MSIN
+
+<img src="/img/dp-cases/nyu-cmu-msin-02.png" alt="Second original Chinese conversation screenshot of an NYU undergraduate admitted to CMU MSIN" style={{display: 'block', width: '90%', height: 'auto', margin: '0 auto'}} />
+
+## Case 3: Jiao Tong–UMich Joint Undergraduate Program — Admitted to CMU and Cornell MEng CS
+
+GPA around 3.8, with some AI experience but limited project depth. The student ultimately chose Cornell MEng CS.
+
+<img src="/img/dp-cases/umich-cornell-meng-cs.png" alt="Original Chinese screenshot of a Jiao Tong–UMich joint undergraduate program student admitted to CMU and Cornell MEng CS" style={{display: 'block', width: '90%', height: 'auto', margin: '0 auto'}} />
+
+## Case 4: Joint Chinese–International Undergraduate Program — Admitted to CMU SESV
+
+The US partner university was ranked outside the Top 100. The student had an internship arranged through family connections and on-campus research experience, but no research output.
+
+<img src="/img/dp-cases/joint-cmu-sesv.png" alt="Original Chinese screenshot of a joint Chinese–international undergraduate program student admitted to CMU SESV" style={{display: 'block', width: '90%', height: 'auto', margin: '0 auto'}} />
+
+## Case 5: Jiao Tong–UMich Joint Undergraduate Program — Admitted to UChicago CS
+
+GPA around 3.6, with results from AI work but relatively limited industry experience.
+
+<img src="/img/dp-cases/umich-uchicago-cs.png" alt="Original Chinese screenshot of a Jiao Tong–UMich joint undergraduate program student admitted to UChicago CS" style={{display: 'block', width: '90%', height: 'auto', margin: '0 auto'}} />
+
+## Case 6: UCLA CS Undergraduate — Admitted to CMU MISM and UIUC MCS
+
+GPA around 3.7, with only the Heima Dianping coding project and no internship or research experience. The student ultimately chose a new-grad SDE position at a major US technology company.
+
+<img src="/img/dp-cases/ucla-cmu-mism-uiuc-mcs-new-grad-sde.png" alt="Original Chinese screenshot of a UCLA CS undergraduate admitted to CMU MISM and UIUC MCS who chose a new-grad SDE position" style={{display: 'block', width: '90%', height: 'auto', margin: '0 auto'}} />

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "test:seo": "node --test scripts/seo-audit.test.mjs",
     "test:analytics": "node --test src/lib/analytics/events.test.mjs",
     "test:migration": "node --test scripts/migration-integrity.test.mjs",
-    "test:gpa-filter": "node --test src/lib/dp/gpa-filter.test.mjs"
+    "test:gpa-filter": "node --test src/lib/dp/gpa-filter.test.mjs",
+    "test:ux": "node --test scripts/locale-navigation.test.mjs src/lib/tracker/*.test.mjs src/lib/dp/page-regressions.test.mjs"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/scripts/locale-navigation.test.mjs
+++ b/scripts/locale-navigation.test.mjs
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict';
+import {readFileSync} from 'node:fs';
+import {createRequire} from 'node:module';
+import test from 'node:test';
+import {transformSync} from '@babel/core';
+import * as paths from '../src/lib/seo/localizedAlternates.mjs';
+
+const require = createRequire(import.meta.url);
+const filename = new URL('../src/theme/NavbarItem/LocaleDropdownNavbarItem/index.js', import.meta.url);
+const {code} = transformSync(readFileSync(filename, 'utf8'), {
+  filename: filename.pathname,
+  configFile: false,
+  babelrc: false,
+  presets: [[require.resolve('@babel/preset-react'), {runtime: 'classic'}]],
+  plugins: [require.resolve('@babel/plugin-transform-modules-commonjs')],
+});
+
+// Exercise the real navbar component's generated items, including the hydration
+// boundary. Browser regression additionally verifies the final DOM and clicks.
+function renderItems({pathname, search = '', hash = '', hydrated = true, queryString = ''}) {
+  const module = {exports: {}};
+  const mocks = {
+    '@docusaurus/useDocusaurusContext': () => ({i18n: {
+      currentLocale: pathname.startsWith('/en/') ? 'en' : 'zh-Hans',
+      locales: ['zh-Hans', 'en'],
+      localeConfigs: {'zh-Hans': {label: '中文', htmlLang: 'zh-Hans'}, en: {label: 'English', htmlLang: 'en-US'}},
+    }}),
+    '@docusaurus/theme-common/internal': {useAlternatePageUtils: () => ({
+      createUrl: ({locale}) => paths.localizedInternalPath(pathname, locale),
+    })},
+    '@docusaurus/Translate': {translate: ({message}) => message},
+    '@docusaurus/router': {useLocation: () => ({pathname, search, hash})},
+    '@docusaurus/useIsBrowser': () => hydrated,
+    '@theme/NavbarItem/DropdownNavbarItem': () => null,
+    '@theme/Icon/Language': () => null,
+    '../../../lib/seo/localizedAlternates.mjs': paths,
+    './styles.module.css': {},
+  };
+  new Function('require', 'module', 'exports', code)(
+    (id) => Object.hasOwn(mocks, id) ? mocks[id] : require(id), module, module.exports,
+  );
+  return module.exports.default({dropdownItemsBefore: [], dropdownItemsAfter: [], queryString}).props.items;
+}
+
+test('initial hydration matches static HTML before adding the live order query', () => {
+  const state = {pathname: '/en/school-positioning-result', search: '?session_id=synthetic', hash: '#report'};
+  const initial = renderItems({...state, hydrated: false});
+  assert.equal(initial[0].to, 'pathname:///school-positioning-result');
+  const hydrated = renderItems(state);
+  assert.equal(hydrated[0].to, 'pathname:///school-positioning-result?session_id=synthetic#report');
+});
+
+test('navbar preserves filter queries after a router location update', () => {
+  const base = {pathname: '/en/datapoints'};
+  assert.equal(renderItems(base)[0].to, 'pathname:///datapoints');
+  assert.equal(renderItems({...base, search: '?school=Harvard&year=2026&gpaMin=3.5', hash: '#results'})[0].to,
+    'pathname:///datapoints?school=Harvard&year=2026&gpaMin=3.5#results');
+});
+
+test('navbar maps the career-change route in each direction', () => {
+  assert.equal(renderItems({pathname: '/转码项目'})[1].to, 'pathname:///en/career-change-programs');
+  assert.equal(renderItems({pathname: '/en/career-change-programs'})[0].to, 'pathname:///转码项目');
+});
+
+test('internal links retain locale and URL state without rewriting external URLs', () => {
+  assert.equal(paths.localizedInternalPath('/', 'en'), '/en/');
+  assert.equal(paths.localizedInternalPath('/en/', 'zh-Hans'), '/');
+  assert.equal(paths.localizedInternalPath('/B/Emory MSCS', 'en'), '/en/B/Emory MSCS');
+  assert.equal(paths.localizedInternalPath('/en/B/Emory MSCS', 'en'), '/en/B/Emory MSCS');
+  assert.equal(paths.localizedInternalPath('/找我辅导?ref=dp#fees', 'en'), '/en/consulting?ref=dp#fees');
+  assert.equal(paths.localizedInternalPath('https://example.com/en/path', 'zh-Hans'), 'https://example.com/en/path');
+  assert.equal(paths.localizedInternalPath('//example.com/path', 'en'), '//example.com/path');
+  assert.equal(paths.localizedInternalPath('#fees', 'en'), '#fees');
+});

--- a/scripts/locale-navigation.test.mjs
+++ b/scripts/locale-navigation.test.mjs
@@ -71,4 +71,5 @@ test('internal links retain locale and URL state without rewriting external URLs
   assert.equal(paths.localizedInternalPath('https://example.com/en/path', 'zh-Hans'), 'https://example.com/en/path');
   assert.equal(paths.localizedInternalPath('//example.com/path', 'en'), '//example.com/path');
   assert.equal(paths.localizedInternalPath('#fees', 'en'), '#fees');
+  assert.equal(paths.localizedInternalPath('/en//example.com/path', 'zh-Hans'), '/example.com/path');
 });

--- a/scripts/seo-audit-baseline.txt
+++ b/scripts/seo-audit-baseline.txt
@@ -156,8 +156,5 @@
 [h1-count] /tutorial-basics/yale mscs 1 year must have exactly one non-empty <h1>; found 4
 [h1-count] /useful_docs/中美SDE实习面试侧重点对比 must have exactly one non-empty <h1>; found 3
 [h1-count] /useful_docs/转码需要补的专业课 must have exactly one non-empty <h1>; found 3
-[hreflang-target-missing] /en/career-change-programs hreflang x-default targets missing page https://csgrad.com/career-change-programs
-[hreflang-target-missing] /en/career-change-programs hreflang zh-Hans targets missing page https://csgrad.com/career-change-programs
-[hreflang-target-missing] /转码项目 hreflang en-US targets missing page https://csgrad.com/en/转码项目
 [title-duplicate] /A/Yale MSCS and /tutorial-basics/yale mscs 1 year share the title "Yale mscs 1 year | CS Grad"
 [title-duplicate] /en/A/Yale MSCS and /en/tutorial-basics/yale mscs 1 year share the title "Yale MSCS 1 Year | CS Grad"

--- a/scripts/seo-audit.mjs
+++ b/scripts/seo-audit.mjs
@@ -225,6 +225,18 @@ async function main() {
     pagesByRoute.set(routeKey(pageRoute(page.file)), page);
   }
 
+  // Navigation and SEO alternate tags can diverge. Validate the links that
+  // visitors actually click, including pages intentionally excluded from SEO.
+  for (const page of pages) {
+    for (const attrs of tags(page.html, 'a').map(attributes)) {
+      if (!attrs.lang || !attrs.href?.startsWith('/') || attrs.href.startsWith('//')) continue;
+      const target = new URL(attrs.href.replace(/&amp;/g, '&'), 'https://csgrad.com');
+      if (!pagesByRoute.has(routeKey(target.pathname))) {
+        issues.push(`[locale-navigation-target-missing] ${pageRoute(page.file)} language ${attrs.lang} targets missing page ${attrs.href}`);
+      }
+    }
+  }
+
   const sitemapFiles = await findFiles(buildDir, (file) => /(?:^|\/)sitemap[^/]*\.xml$/i.test(file));
   if (sitemapFiles.length === 0) {
     issues.push('[sitemap-missing] no sitemap XML files were found');

--- a/scripts/seo-audit.test.mjs
+++ b/scripts/seo-audit.test.mjs
@@ -11,6 +11,18 @@ import {
 
 const scriptPath = fileURLToPath(new URL('./seo-audit.mjs', import.meta.url));
 
+test('maps career-change pages in both directions instead of generating missing routes', () => {
+  const fallback = (locale) => locale === 'en'
+    ? 'https://csgrad.com/en/转码项目'
+    : 'https://csgrad.com/career-change-programs';
+  for (const pathname of ['/转码项目', '/en/career-change-programs']) {
+    assert.equal(localizedAlternateUrl({pathname, locale: 'en', siteUrl: 'https://csgrad.com', fallback}),
+      'https://csgrad.com/en/career-change-programs');
+    assert.equal(localizedAlternateUrl({pathname, locale: 'zh-Hans', siteUrl: 'https://csgrad.com', fallback}),
+      'https://csgrad.com/转码项目');
+  }
+});
+
 test('maps the consulting pages to their real localized URLs', () => {
   const fallback = (locale) => `https://csgrad.com/${locale}/wrong`;
 
@@ -91,6 +103,7 @@ async function writePage(root, route, {
   canonical,
   h1,
   hreflangs = [],
+  navigationLinks = [],
   noindex = false,
 }) {
   const relativePath = route === '/'
@@ -108,8 +121,24 @@ async function writePage(root, route, {
     ${canonical === undefined ? '' : `<link href="${canonical}" rel="canonical">`}
     ${noindex ? '<meta content="noindex,follow" name="robots">' : ''}
     ${alternates}
-  </head><body>${headings.map((heading) => `<h1>${heading}</h1>`).join('')}</body></html>`);
+  </head><body>${headings.map((heading) => `<h1>${heading}</h1>`).join('')}
+  ${navigationLinks.map(({lang, href}) => `<a lang="${lang}" href="${href}">Language</a>`).join('')}
+  </body></html>`);
 }
+
+test('rejects missing language-menu targets even when SEO alternates are valid', async () => {
+  await withSite(async ({page, sitemap, audit}) => {
+    await page('/', {
+      title: 'Home', description: 'Home page', canonical: 'https://csgrad.com/', h1: 'Home',
+      hreflangs: [{lang: 'zh-Hans', href: 'https://csgrad.com/'}],
+      navigationLinks: [{lang: 'en-US', href: '/en/missing?school=Harvard#results'}],
+    });
+    await sitemap(['https://csgrad.com/']);
+    const result = audit();
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /locale-navigation-target-missing/);
+  });
+});
 
 async function writeSitemap(root, routes) {
   const urls = routes.map((route) => `<url><loc>${route}</loc></url>`).join('');

--- a/src/lib/dp/api.js
+++ b/src/lib/dp/api.js
@@ -152,20 +152,21 @@ function buildUrl(path, params) {
 
 // Counts for the header. Prefer the live worker (/api/stats) so newly
 // submitted DPs are reflected; fall back to the frozen snapshot if the
-// worker is unreachable.
+// worker is unreachable. Preserve provenance so the page can label snapshots
+// and show unknown (not zero) when neither source can be loaded.
 export async function getCounts() {
   try {
     const r = await fetch(`${DP_API_BASE}/api/stats`, { credentials: 'include' });
-    if (r.ok) return await r.json();
+    if (r.ok) return { ...await r.json(), source: 'api' };
     throw new Error(`HTTP ${r.status}`);
   } catch (err) {
     warnDev('getCounts live fetch failed, falling back to snapshot:', err && err.message ? err.message : err);
     try {
       const snap = await loadSnapshot();
-      return snap.counts;
+      return { ...snap.counts, source: 'snapshot' };
     } catch (err2) {
       warnDev('getCounts snapshot fallback failed:', err2 && err2.message ? err2.message : err2);
-      return { applicants: 0, programs: 0, datapoints: 0 };
+      return { applicants: null, programs: null, datapoints: null, source: 'unavailable' };
     }
   }
 }

--- a/src/lib/dp/page-regressions.test.mjs
+++ b/src/lib/dp/page-regressions.test.mjs
@@ -1,0 +1,143 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {elements, pageHarness, visibleText} from './page-test-harness.mjs';
+
+const authImports = {
+  '@site/src/lib/auth/SignInButtons': () => null,
+  '@site/src/lib/auth/oauth': {startOAuth() { throw new Error('OAuth must not run'); }},
+};
+const emptyOptions = {schools: [], tiers: [], years: [], ugCats: [], majors: []};
+
+for (const locale of ['zh-Hans', 'en']) {
+  test(`${locale}: failed DP load is distinct from empty results and can retry`, async () => {
+    let attempts = 0;
+    const harness = pageHarness('datapoints', ['Table', 'COPY'], {
+      locale,
+      imports: {
+        ...authImports,
+        '@site/src/lib/dp/api': {listDp: async () => {
+          attempts += 1;
+          if (attempts === 1) throw new TypeError('Failed to fetch');
+          return {rows: [], total: 0};
+        }},
+      },
+    });
+    const props = {counts: {datapoints: 1908, applicants: 317, programs: 280, source: 'snapshot'}, filterOpts: emptyOptions, t: harness.exports.COPY[locale], locale};
+    let tree = harness.render('Table', props);
+    assert.doesNotMatch(visibleText(tree), /匹配0|Matched0/);
+    await harness.effects();
+    await harness.timers();
+    tree = harness.render('Table', props);
+    assert.equal(elements(tree, (el) => el.type?.name === 'EmptyState').length, 0, 'network failure must not render an empty-result component');
+    assert.doesNotMatch(visibleText(tree), /匹配0|Matched0|Failed to fetch/);
+    assert.match(visibleText(tree), locale === 'en' ? /snapshot/i : /快照/);
+    const retry = elements(tree, (el) => el.type === 'button' && /重试|Retry/.test(visibleText(el)))[0];
+    assert.ok(retry, 'a failed request offers retry');
+    retry.props.onClick();
+    harness.render('Table', props);
+    await harness.effects();
+    await harness.timers();
+    tree = harness.render('Table', props);
+    assert.equal(attempts, 2, 'retry performs a new list request');
+    assert.equal(elements(tree, (el) => el.type?.name === 'EmptyState').length, 1, 'a successful empty response renders the real empty state');
+    assert.match(visibleText(tree), locale === 'en' ? /Matched/ : /匹配/);
+  });
+
+  test(`${locale}: corrected applicant form clears old validation error before sign-in`, async () => {
+    const harness = pageHarness('submit-dp', ['Inner'], {
+      locale,
+      imports: {...authImports, '@site/src/lib/dp/api': {getMe: async () => ({user: null})}},
+    });
+    harness.render('Inner');
+    await harness.effects();
+    let tree = harness.render('Inner');
+    const getForm = () => elements(tree, (el) => el.type?.name === 'ApplicantForm')[0];
+    await getForm().props.onSave();
+    tree = harness.render('Inner');
+    assert.match(visibleText(tree), locale === 'en' ? /required fields/i : /请填写必填字段/);
+    for (const [key, value] of Object.entries({ug_school_category: '美本', ug_school_name: 'E2E synthetic', graduation_year: '2028', ug_major: 'CS'})) {
+      getForm().props.setField(key, value);
+      tree = harness.render('Inner');
+    }
+    await getForm().props.onSave();
+    tree = harness.render('Inner');
+    assert.equal(elements(tree, (el) => el.type?.name === 'SignInPromptModal').length, 1);
+    assert.doesNotMatch(visibleText(tree), /required fields|请填写必填字段/i);
+    const backLink = elements(tree, (el) => el.type === 'a' && /DataPoints/.test(visibleText(el)))[0];
+    assert.equal(backLink.props.href, locale === 'en' ? '/en/datapoints' : '/datapoints');
+  });
+
+  test(`${locale}: changing DP filters updates the router while retaining other query parameters`, async () => {
+    const pathname = locale === 'en' ? '/en/datapoints' : '/datapoints';
+    const window = {
+      location: {pathname, search: '?school=Harvard&utm_source=e2e', hash: '#filters'},
+      innerWidth: 1200, addEventListener() {}, removeEventListener() {},
+      history: {replaceState() { throw new Error('Native history does not notify the language menu'); }},
+    };
+    const destinations = [];
+    const history = {replace(destination) { destinations.push(destination); }};
+    const harness = pageHarness('datapoints', ['Table', 'COPY'], {
+      locale,
+      globals: {window},
+      imports: {
+        ...authImports,
+        '@docusaurus/router': {useHistory: () => history},
+        '@site/src/lib/dp/api': {listDp: async () => ({rows: [], total: 0})},
+      },
+    });
+    const props = {counts: {source: 'unavailable'}, filterOpts: emptyOptions, t: harness.exports.COPY[locale], locale};
+    let tree = harness.render('Table', props);
+    const schoolSelect = () => elements(tree, (el) => el.type?.name === 'Select' && el.props.label === props.t.filterSchool)[0];
+    assert.equal(schoolSelect().props.value, 'Harvard', 'initial query filters survive hydration');
+    await harness.effects();
+    assert.equal(destinations.length, 0, 'unchanged initial filters do not trigger navigation');
+    schoolSelect().props.onChange('MIT');
+    tree = harness.render('Table', props);
+    await harness.effects();
+    assert.deepEqual(destinations, [`${pathname}?school=MIT&utm_source=e2e#filters`]);
+    assert.doesNotMatch(visibleText(tree), /1908|317|280/);
+    assert.match(visibleText(tree), locale === 'en' ? /Database totals are temporarily unavailable/ : /暂时无法获取数据库总量/);
+  });
+
+  test(`${locale}: result polling does not claim payment confirmation and localizes connection failures`, async () => {
+    const harness = pageHarness('school-positioning-result', ['ResultBody'], {
+      locale,
+      imports: {
+        '@site/src/lib/positioning/api': {WORKER_BASE_URL: 'https://isolated.invalid'},
+        '@site/src/lib/analytics/events.mjs': {trackSeoEvent() { throw new Error('No analytics expected'); }},
+        '@site/src/lib/analytics/purchase.mjs': {},
+      },
+      globals: {
+        window: {location: {search: '?session_id=e2e_synthetic'}},
+        fetch: async () => { throw new TypeError('Failed to fetch'); },
+      },
+    });
+    let tree = harness.render('ResultBody');
+    assert.doesNotMatch(visibleText(tree), /Stripe/);
+    await harness.effects();
+    harness.render('ResultBody');
+    await harness.effects();
+    for (let count = 0; count < 4; count += 1) await harness.timers();
+    tree = harness.render('ResultBody');
+    assert.doesNotMatch(visibleText(tree), /Failed to fetch/);
+    assert.match(visibleText(tree), locale === 'en' ? /connection/i : /网络/);
+    assert.ok(elements(tree, (el) => el.type === 'button' && /重试|Retry/.test(visibleText(el))).length);
+  });
+}
+
+for (const outcome of ['api', 'snapshot', 'unavailable']) {
+  test(`DP totals identify ${outcome} provenance instead of inventing a live zero`, async () => {
+    const harness = pageHarness('datapoints', ['COPY'], {
+      imports: authImports,
+      globals: {fetch: async (url) => {
+        if (url.endsWith('/api/stats') && outcome === 'api') return {ok: true, json: async () => ({datapoints: 25, applicants: 10, programs: 8})};
+        if (url === '/data/dp-snapshot.json' && outcome === 'snapshot') return {ok: true, json: async () => ({counts: {datapoints: 20, applicants: 9, programs: 7}})};
+        return {ok: false, status: 503};
+      }},
+    });
+    const {getCounts} = harness.loadModule('src/lib/dp/api.js');
+    const counts = await getCounts();
+    assert.equal(counts.source, outcome);
+    assert.equal(counts.datapoints, outcome === 'api' ? 25 : outcome === 'snapshot' ? 20 : null);
+  });
+}

--- a/src/lib/dp/page-test-harness.mjs
+++ b/src/lib/dp/page-test-harness.mjs
@@ -1,0 +1,123 @@
+// Runs the actual JSX component and its event/effect callbacks without a browser,
+// a Docusaurus build, or network access. Browser integration is verified separately.
+import {readFileSync} from 'node:fs';
+import {createRequire} from 'node:module';
+import {dirname, resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
+import vm from 'node:vm';
+import React from 'react';
+import {transformSync} from '@babel/core';
+
+const require = createRequire(import.meta.url);
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+const plugins = [require.resolve('@babel/plugin-transform-react-jsx'), require.resolve('@babel/plugin-transform-modules-commonjs')];
+
+export function pageHarness(page, names, {locale = 'zh-Hans', imports = {}, globals = {}} = {}) {
+  let cursor = 0;
+  const slots = [];
+  const effects = [];
+  const timers = new Map();
+  let nextTimer = 0;
+  const hooks = {
+    ...React,
+    useState(initial) {
+      const index = cursor++;
+      if (!(index in slots)) slots[index] = {value: typeof initial === 'function' ? initial() : initial};
+      return [slots[index].value, (next) => {
+        slots[index].value = typeof next === 'function' ? next(slots[index].value) : next;
+      }];
+    },
+    useRef(initial) {
+      const index = cursor++;
+      return (slots[index] ??= {current: initial});
+    },
+    useMemo(factory, deps) {
+      const index = cursor++;
+      if (!sameDeps(slots[index]?.deps, deps)) slots[index] = {deps, value: factory()};
+      return slots[index].value;
+    },
+    useCallback(callback, deps) { return hooks.useMemo(() => callback, deps); },
+    useEffect(callback, deps) {
+      const index = cursor++;
+      if (!sameDeps(slots[index]?.deps, deps)) {
+        const previous = slots[index];
+        slots[index] = {deps};
+        effects.push(() => {
+          previous?.cleanup?.();
+          slots[index].cleanup = callback();
+        });
+      }
+    },
+  };
+  const cache = new Map();
+  const window = {
+    location: {search: '', pathname: `/${page}`, hash: ''},
+    history: {replaceState() {}}, innerWidth: 1200,
+    addEventListener() {}, removeEventListener() {},
+  };
+  const context = vm.createContext({
+    console, URL, URLSearchParams, window,
+    document: {getElementById() { return {focus() {}}; }},
+    setTimeout(callback) { const id = ++nextTimer; timers.set(id, callback); return id; },
+    clearTimeout(id) { timers.delete(id); },
+    fetch() { throw new Error('Unexpected network access in page regression test'); },
+    ...globals,
+  });
+  const history = {replace() {}};
+  function load(filename, expose = []) {
+    if (cache.has(filename)) return cache.get(filename);
+    const source = readFileSync(filename, 'utf8') + (expose.length ? `\nexport {${expose.join(',')}};` : '');
+    const {code} = transformSync(source, {filename, configFile: false, babelrc: false, plugins});
+    const module = {exports: {}};
+    const localRequire = (specifier) => {
+      if (specifier in imports) return imports[specifier];
+      if (specifier === 'react') return hooks;
+      if (specifier.endsWith('.css')) return new Proxy({}, {get: (_, key) => key});
+      if (specifier === '@docusaurus/useDocusaurusContext') return () => ({i18n: {currentLocale: locale}});
+      if (specifier === '@docusaurus/router') return {useHistory: () => history};
+      if (specifier.startsWith('@theme/') || specifier.startsWith('@docusaurus/')) return ({children}) => children;
+      if (specifier.startsWith('@site/') || specifier.startsWith('.')) {
+        let target = specifier.startsWith('@site/') ? resolve(root, specifier.slice(6)) : resolve(dirname(filename), specifier);
+        if (!/\.(?:mjs|jsx|js)$/.test(target)) target += '.js';
+        return load(target);
+      }
+      return require(specifier);
+    };
+    const evaluate = vm.runInContext(`(function(require, module, exports) {${code}\n})`, context, {filename});
+    evaluate(localRequire, module, module.exports);
+    cache.set(filename, module.exports);
+    return module.exports;
+  }
+  const exports = load(resolve(root, `src/pages/${page}.jsx`), names);
+  return {
+    exports,
+    loadModule(relativePath) { return load(resolve(root, relativePath)); },
+    render(name, props = {}) { cursor = 0; return exports[name](props); },
+    async effects() {
+      for (const effect of effects.splice(0)) effect();
+      await Promise.resolve();
+      await Promise.resolve();
+    },
+    async timers() {
+      const pending = [...timers.values()];
+      timers.clear();
+      for (const callback of pending) await callback();
+    },
+  };
+}
+
+function sameDeps(previous, next) {
+  return Boolean(previous && next && previous.length === next.length && next.every((value, index) => Object.is(value, previous[index])));
+}
+
+export function elements(tree, predicate) {
+  if (Array.isArray(tree)) return tree.flatMap((child) => elements(child, predicate));
+  if (!tree || typeof tree !== 'object') return [];
+  return [...(predicate(tree) ? [tree] : []), ...elements(tree.props?.children, predicate)];
+}
+
+export function visibleText(tree) {
+  if (Array.isArray(tree)) return tree.map(visibleText).join('');
+  if (typeof tree === 'string' || typeof tree === 'number') return String(tree);
+  return tree?.props ? visibleText(tree.props.children) : '';
+}

--- a/src/lib/seo/localizedAlternates.mjs
+++ b/src/lib/seo/localizedAlternates.mjs
@@ -3,6 +3,10 @@ const localizedRouteGroups = Object.freeze([
     'zh-Hans': '/找我辅导',
     en: '/en/consulting',
   }),
+  Object.freeze({
+    'zh-Hans': '/转码项目',
+    en: '/en/career-change-programs',
+  }),
 ]);
 
 function normalizePathname(pathname) {
@@ -36,4 +40,14 @@ export function localizedAlternateUrl({pathname, locale, siteUrl, fallback}) {
   const alternatePath = localizedAlternatePath(pathname, locale);
   if (!alternatePath) return fallback(locale);
   return `${siteUrl.replace(/\/+$/, '')}${alternatePath}`;
+}
+
+// Internal page links retain their query/hash; SEO alternates above stay route-only.
+export function localizedInternalPath(href, locale) {
+  if (typeof href !== 'string' || !href.startsWith('/') || href.startsWith('//')) return href;
+  const [, pathname, suffix] = href.match(/^([^?#]*)(.*)$/);
+  const mapped = localizedAlternatePath(pathname, locale);
+  if (mapped) return `${mapped}${suffix}`;
+  const unlocalized = pathname.replace(/^\/en(?=\/|$)/, '') || '/';
+  return `${locale === 'en' ? `/en${unlocalized}` : unlocalized}${suffix}`;
 }

--- a/src/lib/seo/localizedAlternates.mjs
+++ b/src/lib/seo/localizedAlternates.mjs
@@ -48,6 +48,6 @@ export function localizedInternalPath(href, locale) {
   const [, pathname, suffix] = href.match(/^([^?#]*)(.*)$/);
   const mapped = localizedAlternatePath(pathname, locale);
   if (mapped) return `${mapped}${suffix}`;
-  const unlocalized = pathname.replace(/^\/en(?=\/|$)/, '') || '/';
+  const unlocalized = pathname.replace(/^\/en(?=\/|$)/, '').replace(/^\/+/, '/') || '/';
   return `${locale === 'en' ? `/en${unlocalized}` : unlocalized}${suffix}`;
 }

--- a/src/lib/tracker/backup.mjs
+++ b/src/lib/tracker/backup.mjs
@@ -1,0 +1,33 @@
+export const TRACKER_BACKUP_KEY = 'csgrad_tracker_before_import';
+export const MAX_BACKUP_BYTES = 10 * 1024 * 1024;
+const columns = new Set(['reach', 'match', 'target', 'safety']);
+const essayStatuses = new Set(['not_started', 'drafting', 'reviewing', 'done']);
+const stringFields = ['id', 'school', 'program', 'deadline', 'toefl', 'gre', 'notes', 'tier', 'slug'];
+
+/** Validate the existing exported-array format before changing any saved data. */
+export function parseTrackerBackup(raw) {
+  const cards = JSON.parse(raw);
+  if (!Array.isArray(cards)) throw new Error('invalid-backup');
+  const ids = new Set();
+  for (const card of cards) {
+    if (!card || typeof card !== 'object' || Array.isArray(card)
+      || stringFields.some((key) => typeof card[key] !== 'string')
+      || !card.id.trim() || ids.has(card.id)
+      || (!card.school && !card.program)
+      || !columns.has(card.column) || !essayStatuses.has(card.essayStatus)
+      || typeof card.fromLibrary !== 'boolean'
+      || !Array.isArray(card.lors)
+      || card.lors.some((lor) => !lor || typeof lor.name !== 'string' || typeof lor.done !== 'boolean')
+      || (card.libraryId !== undefined && (typeof card.libraryId !== 'string' || !card.libraryId.trim()))
+      || (card.fromLibrary && !card.libraryId)
+      || (card.slug && (!card.slug.startsWith('/') || card.slug.startsWith('//') || /[\\\u0000-\u001f]/.test(card.slug)))
+    ) throw new Error('invalid-backup');
+    if (card.deadline && (!/^\d{4}-\d{2}-\d{2}$/.test(card.deadline)
+      || Number.isNaN(Date.parse(card.deadline))
+      || new Date(card.deadline).toISOString().slice(0, 10) !== card.deadline)) {
+      throw new Error('invalid-backup');
+    }
+    ids.add(card.id);
+  }
+  return cards;
+}

--- a/src/lib/tracker/dialog.mjs
+++ b/src/lib/tracker/dialog.mjs
@@ -1,0 +1,30 @@
+/** Keyboard handling shared by tracker dialogs; returns cleanup restoring the opener. */
+export function attachDialogBehavior(dialog, onClose) {
+  if (!dialog) return () => {};
+  const doc = dialog.ownerDocument;
+  const opener = doc.activeElement;
+  const focusable = () => [...dialog.querySelectorAll(
+    'button:not([disabled]), a[href], input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), [tabindex="0"]',
+  )].filter((element) => element.getClientRects().length > 0);
+  (dialog.querySelector('[data-dialog-initial-focus]') || focusable()[0] || dialog).focus();
+  const keydown = (event) => {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      onClose();
+    } else if (event.key === 'Tab') {
+      const elements = focusable();
+      const first = elements[0] || dialog;
+      const last = elements.at(-1) || dialog;
+      if (!elements.length || !elements.includes(doc.activeElement)
+        || (event.shiftKey ? doc.activeElement === first : doc.activeElement === last)) {
+        event.preventDefault();
+        (event.shiftKey ? last : first).focus();
+      }
+    }
+  };
+  doc.addEventListener('keydown', keydown);
+  return () => {
+    doc.removeEventListener('keydown', keydown);
+    if (opener?.isConnected) opener.focus();
+  };
+}

--- a/src/lib/tracker/dialog.test.mjs
+++ b/src/lib/tracker/dialog.test.mjs
@@ -1,0 +1,55 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {attachDialogBehavior} from './dialog.mjs';
+
+function fixture() {
+  const listeners = new Map();
+  const doc = {activeElement: null,
+    addEventListener: (name, handler) => listeners.set(name, handler),
+    removeEventListener: (name, handler) => { if (listeners.get(name) === handler) listeners.delete(name); }};
+  const element = () => ({isConnected: true, getClientRects: () => [1], focus() { doc.activeElement = this; }});
+  const opener = element();
+  const first = element();
+  const last = element();
+  opener.focus();
+  const dialog = {...element(), ownerDocument: doc,
+    querySelector: () => first, querySelectorAll: () => [first, last]};
+  let closed = 0;
+  const cleanup = attachDialogBehavior(dialog, () => { closed++; });
+  const key = (value, shiftKey = false) => {
+    let prevented = false;
+    listeners.get('keydown')?.({key: value, shiftKey, preventDefault() { prevented = true; }});
+    return prevented;
+  };
+  return {doc, opener, first, last, key, cleanup, closed: () => closed, listeners};
+}
+
+test('dialog focuses its initial field and Escape closes once', () => {
+  const dialog = fixture();
+  assert.equal(dialog.doc.activeElement, dialog.first);
+  assert.equal(dialog.key('Escape'), true);
+  assert.equal(dialog.closed(), 1);
+  dialog.cleanup();
+  assert.equal(dialog.doc.activeElement, dialog.opener);
+  assert.equal(dialog.listeners.has('keydown'), false);
+});
+
+test('Tab and Shift+Tab remain inside the dialog', () => {
+  const dialog = fixture();
+  dialog.last.focus();
+  assert.equal(dialog.key('Tab'), true);
+  assert.equal(dialog.doc.activeElement, dialog.first);
+  assert.equal(dialog.key('Tab', true), true);
+  assert.equal(dialog.doc.activeElement, dialog.last);
+  dialog.opener.focus();
+  assert.equal(dialog.key('Tab'), true);
+  assert.equal(dialog.doc.activeElement, dialog.first);
+  dialog.cleanup();
+});
+
+test('ordinary keys do not dismiss the dialog or interfere with input', () => {
+  const dialog = fixture();
+  assert.equal(dialog.key('a'), false);
+  assert.equal(dialog.closed(), 0);
+  dialog.cleanup();
+});

--- a/src/lib/tracker/tracker.test.mjs
+++ b/src/lib/tracker/tracker.test.mjs
@@ -1,0 +1,315 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import {createRequire} from 'node:module';
+
+const require = createRequire(import.meta.url);
+const babel = require('@babel/core');
+const pagePath = path.resolve('src/pages/tracker.jsx');
+
+function fixture(overrides = {}) {
+  return {id: 'existing', school: 'Test University', program: 'MSCS', column: 'target', deadline: '',
+    lors: [{name: 'Reference', done: false}], toefl: '', gre: '', essayStatus: 'not_started', notes: '',
+    fromLibrary: false, tier: '', slug: '', ...overrides};
+}
+
+// Exercise the real page and modal event handlers without a browser/backend.
+// Hooks are scheduled explicitly; browser keyboard/focus behavior is covered separately.
+function mountTracker(initialCards = [], locale = 'zh-Hans', priorStorage) {
+  const frames = new Map();
+  const effects = [];
+  const writes = [];
+  const storageValues = new Map(priorStorage || [['csgrad_tracker_data', typeof initialCards === 'string' ? initialCards : JSON.stringify(initialCards)]]);
+  let failKey = null;
+  let failWrite = () => false;
+  let frame;
+  let cursor;
+  const slot = (create) => {
+    const index = cursor++;
+    if (!(index in frame)) frame[index] = create();
+    return [frame, index];
+  };
+  const react = {
+    createElement: (type, props, ...children) => ({type, props: {...props, children}}),
+    Fragment: 'fragment',
+    useState(initial) {
+      const [state, index] = slot(() => typeof initial === 'function' ? initial() : initial);
+      return [state[index], (next) => { state[index] = typeof next === 'function' ? next(state[index]) : next; }];
+    },
+    useRef(initial) { const [state, index] = slot(() => ({current: initial})); return state[index]; },
+    useMemo(fn) { return fn(); },
+    useCallback(fn) { return fn; },
+    useEffect(fn, deps) {
+      const [state, index] = slot(() => undefined);
+      if (!state[index] || !deps || deps.some((value, i) => value !== state[index][i])) {
+        state[index] = deps;
+        effects.push(fn);
+      }
+    },
+  };
+  const translate = ({message}, values = {}) => message.replace(/\{(\w+)\}/g, (_, key) => values[key] ?? `{${key}}`);
+  const passthrough = ({children}) => children;
+  const mocks = {
+    react,
+    '@theme/Layout': passthrough,
+    '@docusaurus/Head': passthrough,
+    '@docusaurus/Translate': {__esModule: true, default: passthrough, translate},
+    '@docusaurus/useDocusaurusContext': () => ({i18n: {currentLocale: locale}}),
+    '@dnd-kit/core': {DndContext: passthrough, DragOverlay: passthrough, useSensor: () => null,
+      useSensors: () => [], useDroppable: () => ({}), PointerSensor: {}, closestCorners: () => null},
+    '@dnd-kit/sortable': {SortableContext: passthrough, useSortable: () => ({}), arrayMove: (items) => items},
+    '@dnd-kit/utilities': {CSS: {Transform: {toString: () => ''}}},
+  };
+  const cache = new Map();
+  const alerts = [];
+  const storage = {
+    getItem: (key) => storageValues.get(key) ?? null,
+    setItem: (key, value) => {
+      if (key === failKey || failWrite(key, value)) throw new Error('QuotaExceededError');
+      storageValues.set(key, value); writes.push({key, value});
+    },
+    removeItem: (key) => storageValues.delete(key),
+  };
+  class FileReader {
+    readAsText(file) { this.onload({target: {result: file.text}}); }
+  }
+  function load(filename) {
+    if (cache.has(filename)) return cache.get(filename);
+    const code = babel.transformSync(fs.readFileSync(filename, 'utf8'), {filename, babelrc: false, configFile: false,
+      plugins: ['@babel/plugin-transform-react-jsx', '@babel/plugin-transform-modules-commonjs']}).code;
+    const module = {exports: {}};
+    const localRequire = (specifier) => {
+      if (specifier in mocks) return mocks[specifier];
+      if (specifier.endsWith('.css')) return new Proxy({}, {get: (_, name) => name});
+      if (specifier.startsWith('.')) {
+        let resolved = path.resolve(path.dirname(filename), specifier);
+        if (!path.extname(resolved)) resolved += '.js';
+        return load(resolved);
+      }
+      return require(specifier);
+    };
+    new Function('require', 'module', 'exports', 'localStorage', 'FileReader', 'alert', 'fetch', 'document', code)(
+      localRequire, module, module.exports, storage, FileReader, (msg) => alerts.push(msg),
+      () => Promise.resolve({json: () => Promise.resolve([])}), {activeElement: null});
+    cache.set(filename, module.exports);
+    return module.exports;
+  }
+  const Page = load(pagePath).default;
+  function expand(node, key = 'root') {
+    if (node == null || typeof node === 'boolean') return null;
+    if (Array.isArray(node)) return node.flatMap((child, index) => expand(child, `${key}/${index}`));
+    if (typeof node !== 'object') return node;
+    if (typeof node.type === 'function') {
+      const id = `${key}:${node.type.name}`;
+      if (!frames.has(id)) frames.set(id, []);
+      frame = frames.get(id);
+      cursor = 0;
+      return expand(node.type(node.props), id);
+    }
+    return {...node, props: {...node.props, children: expand(node.props.children, key)}};
+  }
+  let tree;
+  const render = () => { tree = expand(react.createElement(Page, {})); return tree; };
+  const all = (predicate, node = tree) => {
+    if (Array.isArray(node)) return node.flatMap((child) => all(predicate, child));
+    if (!node || typeof node !== 'object') return [];
+    return [...(predicate(node) ? [node] : []), ...all(predicate, node.props.children)];
+  };
+  const textOf = (node) => Array.isArray(node) ? node.map(textOf).join('')
+    : node && typeof node === 'object' ? textOf(node.props.children) : node == null ? '' : String(node);
+  const button = (label) => all((node) => node.type === 'button' && textOf(node).includes(label))[0];
+  const flush = () => { effects.splice(0).forEach((fn) => fn()); render(); };
+  const importFile = (data) => {
+    all((node) => node.type === 'input' && node.props.type === 'file')[0].props.onChange({target: {
+      files: [{text: typeof data === 'string' ? data : JSON.stringify(data)}], value: 'fixture.json'}});
+    render();
+  };
+  render(); flush(); flush();
+  return {render, flush, all, button, textOf, importFile, alerts, writes,
+    storageSnapshot: () => new Map(storageValues),
+    failWritesTo: (key) => { failKey = key; },
+    failWritesWhen: (predicate) => { failWrite = predicate; },
+    raw: () => storageValues.get('csgrad_tracker_data'),
+    saved: () => JSON.parse(storageValues.get('csgrad_tracker_data'))};
+}
+
+test('custom add persists the category selected in the real modal callback', () => {
+  for (const column of ['reach', 'match', 'target', 'safety']) {
+    const page = mountTracker();
+    page.button('添加自定义项目').props.onClick(); page.render();
+    page.all((node) => node.type === 'input' && node.props.placeholder === '如: Stanford University')[0]
+      .props.onChange({target: {value: 'E2E University'}}); page.render();
+    page.all((node) => node.type === 'select' && node.props.value === 'reach')[0]
+      .props.onChange({target: {value: column}}); page.render();
+    page.all((node) => node.type === 'button' && page.textOf(node) === '添加项目')[0].props.onClick();
+    page.render(); page.flush();
+    assert.equal(page.saved()[0].column, column);
+  }
+});
+
+test('invalid backup never replaces existing persisted cards', () => {
+  const original = [fixture()];
+  const page = mountTracker(original);
+  page.importFile([fixture({column: 'invisible-column'})]);
+  page.flush();
+  assert.deepEqual(page.saved(), original);
+  assert.match(page.textOf(page.all((node) => node.props.role === 'status')), /导入失败/);
+});
+
+test('valid backups require explicit replacement, cancel safely, and can be undone', () => {
+  const original = [fixture()];
+  const incoming = [fixture({id: 'new-card', school: 'Another University', column: 'safety'})];
+  const page = mountTracker(original);
+  page.importFile(incoming); page.flush();
+  assert.deepEqual(page.saved(), original);
+  assert.match(page.textOf(page.all((node) => node.props.role === 'alertdialog')), /替换.*不是合并/);
+  page.button('取消').props.onClick(); page.render(); page.flush();
+  assert.deepEqual(page.saved(), original);
+  page.importFile(incoming);
+  page.button('确认替换').props.onClick(); page.render(); page.flush();
+  assert.deepEqual(page.saved(), incoming);
+  page.button('撤销最近导入').props.onClick(); page.render();
+  page.button('取消').props.onClick(); page.render(); page.flush();
+  assert.deepEqual(page.saved(), incoming);
+  page.button('撤销最近导入').props.onClick(); page.render();
+  page.button('恢复旧清单').props.onClick(); page.render(); page.flush();
+  assert.deepEqual(page.saved(), original);
+});
+
+test('invalid array entries, duplicate IDs, malformed nested fields and non-array JSON are rejected by import', () => {
+  const invalid = [
+    {}, [null], [fixture(), fixture()], [fixture({lors: undefined})],
+    [fixture({id: ''})], [fixture({lors: [{name: 'Ref', done: 'yes'}]})],
+    [fixture({essayStatus: 'unknown'})], [fixture({deadline: '2026-02-30'})],
+    [fixture({slug: 'javascript:alert(1)'})], [fixture({slug: '//outside.example'})],
+    [fixture({fromLibrary: true})], [fixture({school: '', program: ''})], 'not json',
+  ];
+  for (const data of invalid) {
+    const original = [fixture()];
+    const page = mountTracker(original);
+    page.importFile(data); page.flush();
+    assert.deepEqual(page.saved(), original);
+    assert.equal(page.all((node) => node.props.role === 'alertdialog').length, 0);
+    assert.match(page.textOf(page.all((node) => node.props.role === 'status')), /导入失败/);
+  }
+});
+
+test('existing export format permits empty backups and school-only/program-only records', () => {
+  for (const incoming of [[], [fixture({program: ''})], [fixture({school: ''})],
+    [fixture({fromLibrary: true, libraryId: 'emory-mscs', slug: '/B/Emory MSCS', lors: []})]]) {
+    const page = mountTracker([fixture()]);
+    page.importFile(incoming);
+    page.button('确认替换').props.onClick(); page.render(); page.flush();
+    assert.deepEqual(page.saved(), incoming);
+  }
+});
+
+test('initial hydration never writes an empty list over existing saved cards', () => {
+  const original = [fixture()];
+  const page = mountTracker(original);
+  assert.ok(page.writes.length > 0);
+  assert.ok(page.writes.every(({value}) => value === JSON.stringify(original)));
+});
+
+test('unreadable legacy saved data remains intact and blocks empty-state editing', () => {
+  for (const raw of ['invalid json', JSON.stringify([fixture({column: 'legacy-invalid'})])]) {
+    const page = mountTracker(raw);
+    assert.equal(page.raw(), raw);
+    assert.equal(page.writes.length, 0);
+    assert.equal(page.button('添加自定义项目').props.disabled, true);
+    assert.match(page.textOf(page.all((node) => node.props.role === 'alert')), /原始数据已保留/);
+  }
+});
+
+test('storage failure during backup or replacement keeps the current list unchanged', () => {
+  for (const key of ['csgrad_tracker_before_import', 'csgrad_tracker_data']) {
+    const original = [fixture()];
+    const page = mountTracker(original);
+    page.importFile([fixture({id: 'new'})]);
+    page.failWritesTo(key);
+    page.button('确认替换').props.onClick(); page.render(); page.flush();
+    assert.deepEqual(page.saved(), original);
+    assert.match(page.textOf(page.all((node) => node.props.role === 'status')), /导入未完成/);
+  }
+});
+
+test('failed second import preserves the current list and the original undo backup', () => {
+  const original = [fixture()];
+  const firstImport = [fixture({id: 'first-import'})];
+  const page = mountTracker(original);
+  page.importFile(firstImport);
+  page.button('确认替换').props.onClick(); page.render(); page.flush();
+  page.importFile([fixture({id: 'second-import'})]);
+  page.failWritesTo('csgrad_tracker_data');
+  page.button('确认替换').props.onClick(); page.render(); page.flush();
+  assert.deepEqual(page.saved(), firstImport);
+  assert.equal(page.storageSnapshot().get('csgrad_tracker_before_import'), JSON.stringify(original));
+});
+
+test('failed first import removes its temporary undo backup', () => {
+  const original = [fixture()];
+  const page = mountTracker(original);
+  page.importFile([fixture({id: 'new'})]);
+  page.failWritesTo('csgrad_tracker_data');
+  page.button('确认替换').props.onClick(); page.render(); page.flush();
+  assert.deepEqual(page.saved(), original);
+  assert.equal(page.storageSnapshot().has('csgrad_tracker_before_import'), false);
+});
+
+test('failed rollback clearly warns about undo history and disables the undo action', () => {
+  const original = [fixture()];
+  const firstImport = [fixture({id: 'first-import'})];
+  const page = mountTracker(original);
+  page.importFile(firstImport);
+  page.button('确认替换').props.onClick(); page.render(); page.flush();
+  page.importFile([fixture({id: 'second-import'})]);
+  page.failWritesWhen((key, value) => key === 'csgrad_tracker_data'
+    || (key === 'csgrad_tracker_before_import' && value === JSON.stringify(original)));
+  page.button('确认替换').props.onClick(); page.render(); page.flush();
+  assert.deepEqual(page.saved(), firstImport);
+  assert.match(page.textOf(page.all((node) => node.props.role === 'status')), /无法恢复之前的撤销备份/);
+  assert.equal(page.button('撤销最近导入'), undefined);
+});
+
+test('undo backup survives a page reload and restores the previous list', () => {
+  const original = [fixture()];
+  const page = mountTracker(original);
+  page.importFile([fixture({id: 'new'})]);
+  page.button('确认替换').props.onClick(); page.render(); page.flush();
+  const reloaded = mountTracker([], 'zh-Hans', page.storageSnapshot());
+  reloaded.button('撤销最近导入').props.onClick(); reloaded.render();
+  reloaded.button('恢复旧清单').props.onClick(); reloaded.render(); reloaded.flush();
+  assert.deepEqual(reloaded.saved(), original);
+});
+
+test('recovery import preserves unreadable old data and undo restores it without empty-state writes', () => {
+  const original = JSON.stringify([fixture({column: 'unrecognized-legacy-column'})]);
+  const page = mountTracker(original);
+  page.importFile([fixture({id: 'valid-replacement'})]);
+  page.button('确认替换').props.onClick(); page.render(); page.flush();
+  page.button('撤销最近导入').props.onClick(); page.render();
+  page.button('恢复旧清单').props.onClick(); page.render(); page.flush();
+  assert.equal(page.raw(), original);
+  assert.equal(page.button('添加自定义项目').props.disabled, true);
+});
+
+test('English tracker renders localized home and program detail links', () => {
+  const page = mountTracker([fixture({slug: '/B/Emory MSCS'})], 'en');
+  assert.ok(page.all((node) => node.type === 'a' && node.props.href === '/en/').length);
+  assert.ok(page.all((node) => node.type === 'a' && node.props.href === '/en/B/Emory MSCS').length);
+});
+
+test('card and library modals expose accessible dialog semantics and close actions', () => {
+  const page = mountTracker();
+  page.button('添加自定义项目').props.onClick(); page.render();
+  let modal = page.all((node) => node.props.role === 'dialog')[0];
+  assert.equal(modal.props['aria-modal'], 'true');
+  assert.ok(modal.props['aria-labelledby']);
+  page.all((node) => node.type === 'button' && node.props['aria-label'] === '关闭')[0].props.onClick(); page.render();
+  assert.equal(page.all((node) => node.props.role === 'dialog').length, 0);
+  page.button('添加项目').props.onClick(); page.render();
+  modal = page.all((node) => node.props.role === 'dialog')[0];
+  assert.equal(modal.props['aria-modal'], 'true');
+  assert.ok(modal.props['aria-labelledby']);
+});

--- a/src/pages/datapoints.jsx
+++ b/src/pages/datapoints.jsx
@@ -3,8 +3,10 @@ import Layout from '@theme/Layout';
 import BrowserOnly from '@docusaurus/BrowserOnly';
 import Head from '@docusaurus/Head';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import { useHistory } from '@docusaurus/router';
 import { getMe, listDp, getFilterOptions, getCounts } from '@site/src/lib/dp/api';
 import { formatGpaRange, parseGpaRange } from '@site/src/lib/dp/gpa-filter.mjs';
+import { localizedInternalPath } from '@site/src/lib/seo/localizedAlternates.mjs';
 import SignInButtons from '@site/src/lib/auth/SignInButtons';
 import { startOAuth } from '@site/src/lib/auth/oauth';
 import styles from './datapoints.module.css';
@@ -14,7 +16,7 @@ const RESULT_OPTIONS = ['Admit', 'Reject', 'Waitlist', '默拒', 'Withdraw'];
 const MOBILE_BREAKPOINT = 768;
 
 // Pre-hydration / no-JS fallback counts. Refresh when snapshot regenerates.
-const STATIC_COUNTS = { datapoints: 1908, applicants: 317, programs: 280 };
+const STATIC_COUNTS = { datapoints: 1908, applicants: 317, programs: 280, source: 'snapshot' };
 const EMPTY_FILTER_OPTS = { schools: [], tiers: [], years: [], ugCats: [], majors: [] };
 
 const COPY = {
@@ -25,9 +27,14 @@ const COPY = {
     metaApplicants: '位申请者',
     metaPrograms: '个项目',
     metaDatapoints: '条录取数据',
-    dataNote: '注：数据来源于历史 Seatable 归档，个人识别字段（联系方式 / 备注 / 推荐信详情等）已脱敏。',
+    dataNote: '注：数据包含历史 Seatable 归档与后续提交，由在线数据库提供；个人识别字段（联系方式 / 备注 / 推荐信详情等）已脱敏。',
     loadingData: '加载 DataPoints…',
     loadFail: '加载数据失败：',
+    loadErrorTitle: '暂时无法加载 DataPoints',
+    loadErrorHint: '请检查网络连接后重试。当前未能获取结果，不代表没有匹配的案例。',
+    retry: '重试',
+    countsSnapshot: '以上为历史快照总量，可能尚未包含最近提交的数据。',
+    countsUnavailable: '暂时无法获取数据库总量。',
     searchPlaceholder: '搜索学校 / 项目',
     searchLabel: '搜索',
     filterSchool: '学校',
@@ -125,9 +132,14 @@ const COPY = {
     metaApplicants: 'applicants',
     metaPrograms: 'programs',
     metaDatapoints: 'datapoints',
-    dataNote: 'Note: data comes from a historical Seatable archive. Personally identifying fields have been redacted; institution names and free-text notes remain in the language in which they were submitted.',
+    dataNote: 'Note: the live database includes a historical Seatable archive and later submissions. Personally identifying fields have been redacted; institution names and free-text notes remain in the language in which they were submitted.',
     loadingData: 'Loading DataPoints…',
     loadFail: 'Failed to load data: ',
+    loadErrorTitle: 'DataPoints are temporarily unavailable',
+    loadErrorHint: 'Check your connection and try again. Results could not be loaded; this does not mean there are no matching cases.',
+    retry: 'Retry',
+    countsSnapshot: 'These totals are from a historical snapshot and may not include recent submissions.',
+    countsUnavailable: 'Database totals are temporarily unavailable.',
     searchPlaceholder: 'Search school / program',
     searchLabel: 'Search',
     filterSchool: 'School',
@@ -179,6 +191,8 @@ const COPY = {
     closeDialog: 'Close',
     rowClickHint: 'Click to see all DataPoints from this applicant',
     applicantDpsTitle: "Applicant's full DataPoints",
+    submitBtn: 'Submit DataPoints',
+    myDpBtn: 'My DataPoints',
     emptyTitle: 'No matching datapoints.',
     emptyHint: 'Try relaxing your filters:',
     emptyClearAll: 'Clear all filters',
@@ -260,7 +274,7 @@ function readFiltersFromUrl() {
   return out;
 }
 
-function writeFiltersToUrl(filters) {
+function writeFiltersToUrl(filters, history) {
   if (typeof window === 'undefined') return;
   const params = new URLSearchParams(window.location.search);
   for (const k of URL_KEYS) {
@@ -270,7 +284,9 @@ function writeFiltersToUrl(filters) {
   }
   const qs = params.toString();
   const next = `${window.location.pathname}${qs ? `?${qs}` : ''}${window.location.hash}`;
-  window.history.replaceState(null, '', next);
+  const current = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+  // Notify the router so the language menu sees newly selected filters too.
+  if (next !== current) history.replace(next);
 }
 
 // ---------- Static SEO shell ----------
@@ -284,13 +300,14 @@ function StaticHero({ t, counts }) {
       <p className={styles.meta}>
         <b>{counts.datapoints}</b> {t.metaDatapoints} · <b>{counts.applicants}</b> {t.metaApplicants} ·{' '}
         <b>{counts.programs}</b> {t.metaPrograms}      </p>
+      <p className={styles.note}>{t.countsSnapshot}</p>
     </header>
   );
 }
 
 // ---------- Inner: data load orchestration ----------
 
-function Inner({ t }) {
+function Inner({ t, locale }) {
   // Render the page shell immediately with STATIC_COUNTS + empty filter
   // dropdowns; counts/filterOpts populate async without blocking the UI.
   // The Table mounts in parallel and starts fetching rows right away.
@@ -300,9 +317,11 @@ function Inner({ t }) {
   const [error, setError] = useState(null);
   const [me, setMe] = useState(null);
   const [meChecked, setMeChecked] = useState(false);
+  const [reloadKey, setReloadKey] = useState(0);
 
   useEffect(() => {
     let cancelled = false;
+    setError(null);
     Promise.all([getCounts(), getFilterOptions()])
       .then(([c, o]) => {
         if (cancelled) return;
@@ -311,7 +330,7 @@ function Inner({ t }) {
       })
       .catch((e) => !cancelled && setError(String(e)));
     return () => { cancelled = true; };
-  }, []);
+  }, [reloadKey]);
 
   useEffect(() => {
     let cancelled = false;
@@ -326,8 +345,14 @@ function Inner({ t }) {
     return () => { cancelled = true; };
   }, []);
 
-  if (error) return <div className={styles.errorBox}>{t.loadFail}{error}</div>;
-  return <Table counts={counts} filterOpts={filterOpts} me={me} meChecked={meChecked} t={t} />;
+  if (error) return (
+    <div className={styles.errorBox} role="alert">
+      <p>{t.loadErrorTitle}</p>
+      <p>{t.loadErrorHint}</p>
+      <button type="button" onClick={() => setReloadKey((key) => key + 1)}>{t.retry}</button>
+    </div>
+  );
+  return <Table counts={counts} filterOpts={filterOpts} me={me} meChecked={meChecked} t={t} locale={locale} onRetryMetadata={() => setReloadKey((key) => key + 1)} />;
 }
 
 // Header sign-in CTA: delegates to the shared SignInButtons + startOAuth.
@@ -378,7 +403,8 @@ function useIsMobile() {
 
 // ---------- Main Table component ----------
 
-function Table({ counts, filterOpts, me, meChecked, t }) {
+function Table({ counts, filterOpts, me, meChecked, t, locale, onRetryMetadata }) {
+  const history = useHistory();
   const isMobile = useIsMobile();
   const [openApplicantId, setOpenApplicantId] = useState(null);
 
@@ -395,17 +421,18 @@ function Table({ counts, filterOpts, me, meChecked, t }) {
   const gpaRange = useMemo(() => parseGpaRange(gpaMin, gpaMax), [gpaMin, gpaMax]);
 
   useEffect(() => {
-    writeFiltersToUrl({ school, tier, year, result, ugCat, major, gpaMin, gpaMax });
-  }, [school, tier, year, result, ugCat, major, gpaMin, gpaMax]);
+    writeFiltersToUrl({ school, tier, year, result, ugCat, major, gpaMin, gpaMax }, history);
+  }, [school, tier, year, result, ugCat, major, gpaMin, gpaMax, history]);
 
   useEffect(() => setPage(0), [school, tier, year, result, ugCat, major, gpaMin, gpaMax]);
 
-  // Fetch rows from API on filter/page change. Keep previous rows visible
-  // while a new fetch is in flight so the table doesn't blink.
+  // Fetch rows on filter/page change. Only present matches for a completed
+  // request; stale rows/counts must not masquerade as the new filter's results.
   const [rows, setRows] = useState([]);
   const [totalCount, setTotalCount] = useState(0);
   const [loading, setLoading] = useState(true);
   const [apiError, setApiError] = useState(null);
+  const [retryKey, setRetryKey] = useState(0);
   const firstFetchRef = useRef(true);
 
   useEffect(() => {
@@ -415,14 +442,14 @@ function Table({ counts, filterOpts, me, meChecked, t }) {
       return undefined;
     }
     let cancelled = false;
+    setLoading(true);
+    setApiError(null);
     // First fetch fires immediately so the table appears as fast as possible;
     // subsequent filter/page changes get a 250ms debounce to coalesce rapid
     // dropdown clicks.
     const delay = firstFetchRef.current ? 0 : 250;
     firstFetchRef.current = false;
     const handle = setTimeout(async () => {
-      setLoading(true);
-      setApiError(null);
       try {
         const res = await listDp({
           school: school || undefined,
@@ -446,7 +473,14 @@ function Table({ counts, filterOpts, me, meChecked, t }) {
       }
     }, delay);
     return () => { cancelled = true; clearTimeout(handle); };
-  }, [school, tier, year, result, ugCat, major, gpaRange, page]);
+  }, [school, tier, year, result, ugCat, major, gpaRange, page, retryKey]);
+
+  function retryLoad() {
+    setLoading(true);
+    setApiError(null);
+    setRetryKey((key) => key + 1);
+    onRetryMetadata?.();
+  }
 
   const totalPages = Math.max(1, Math.ceil(totalCount / PAGE_SIZE));
   const paged = rows;
@@ -471,12 +505,12 @@ function Table({ counts, filterOpts, me, meChecked, t }) {
         <div className={styles.headerTop}>
           <h1>{t.headerTitle}</h1>
           <div className={styles.headerRight}>
-            <a href="/submit-dp" className={styles.signInBtn} style={{ textDecoration: 'none' }}>
+            <a href={localizedInternalPath('/submit-dp', locale)} className={styles.signInBtn} style={{ textDecoration: 'none' }}>
               {t.submitBtn}
             </a>
             {meChecked && me ? (
               <>
-                <a href="/my-dp" className={styles.signInBtn} style={{ textDecoration: 'none' }}>
+                <a href={localizedInternalPath('/my-dp', locale)} className={styles.signInBtn} style={{ textDecoration: 'none' }}>
                   {t.myDpBtn}
                 </a>
                 <MeBadge me={me} t={t} />
@@ -484,11 +518,11 @@ function Table({ counts, filterOpts, me, meChecked, t }) {
             ) : null}
           </div>
         </div>
-        <p className={styles.meta}>
+        {counts.source === 'unavailable' ? <p className={styles.meta}>{t.countsUnavailable}</p> : <p className={styles.meta}>
           <b>{counts.datapoints}</b> {t.metaDatapoints} · <b>{counts.applicants}</b> {t.metaApplicants} ·{' '}
-          <b>{counts.programs}</b> {t.metaPrograms}        </p>
+          <b>{counts.programs}</b> {t.metaPrograms}</p>}
+        {counts.source === 'snapshot' ? <p className={styles.note}>{t.countsSnapshot}</p> : null}
         <p className={styles.note}>{t.dataNote}</p>
-        {apiError ? <p className={styles.liveErr} role="status"><span aria-hidden="true">⚠️ </span>{t.loadFail}{apiError}</p> : null}
       </header>
 
       <section className={styles.filters} aria-label="filters">
@@ -508,13 +542,19 @@ function Table({ counts, filterOpts, me, meChecked, t }) {
         />
       </section>
 
-      <div className={styles.summary} role="status" aria-live="polite">
+      {!loading && !apiError ? <div className={styles.summary} role="status" aria-live="polite">
         {gpaRange.valid ? (
           <>{t.summaryMatched} <b>{totalCount}</b> {t.summaryRows} · {page + 1} / {totalPages} {t.summaryPage}</>
         ) : t.gpaAwaitingValidRange}
-      </div>
+      </div> : null}
 
-      {!gpaRange.valid ? null : loading && rows.length === 0 ? (
+      {!gpaRange.valid ? null : apiError ? (
+        <div className={styles.errorBox} role="alert">
+          <p><strong>{t.loadErrorTitle}</strong></p>
+          <p>{t.loadErrorHint}</p>
+          <button type="button" className={styles.signInBtn} onClick={retryLoad}>{t.retry}</button>
+        </div>
+      ) : loading ? (
         <div className={styles.loading}>{t.loadingData}</div>
       ) : paged.length === 0 ? (
         <EmptyState t={t} activeFilters={activeFilters} />
@@ -532,7 +572,7 @@ function Table({ counts, filterOpts, me, meChecked, t }) {
         />
       ) : null}
 
-      {gpaRange.valid && totalCount > 0 ? (
+      {gpaRange.valid && !loading && !apiError && totalCount > 0 ? (
         <nav className={styles.pager} aria-label="pagination">
           <button
             disabled={page === 0}
@@ -1164,7 +1204,7 @@ export default function DataPointsPage() {
         <meta property="og:type" content="website" />
       </Head>
       <BrowserOnly fallback={<StaticHero t={t} counts={STATIC_COUNTS} />}>
-        {() => <Inner t={t} />}
+        {() => <Inner t={t} locale={locale} />}
       </BrowserOnly>
     </Layout>
   );

--- a/src/pages/school-positioning-result.jsx
+++ b/src/pages/school-positioning-result.jsx
@@ -50,13 +50,14 @@ const COPY = {
     bucketSafetySub: 'Safety',
     emptyBucket: '该档暂无推荐',
     viewDetail: '了解详情',
-    pendingTitle: '订单处理中',
-    pendingText: 'Stripe 正在确认你的付款，请稍候…',
+    pendingTitle: '正在获取订单状态',
+    pendingText: '正在查询订单与报告状态，请稍候…',
     missingTitle: '缺少 session id',
     missingText: '请通过付款后的回跳链接打开本页面。',
     timeoutTitle: '查询超时',
     timeoutText: '订单还未完成，可能仍在处理中。请稍后通过相同链接重新打开本页面。',
     errorTitle: '加载失败',
+    errorText: '暂时无法获取订单状态。请检查网络连接后重试，或稍后通过原链接重新打开；当前页面无法确认付款是否成功，请勿因此重复付款。',
     retry: '重试',
   },
   en: {
@@ -92,13 +93,14 @@ const COPY = {
     bucketSafetySub: 'Safety',
     emptyBucket: 'No picks in this bucket',
     viewDetail: 'Learn more',
-    pendingTitle: 'Processing your order',
-    pendingText: 'Stripe is confirming your payment, please wait…',
+    pendingTitle: 'Checking order status',
+    pendingText: 'Retrieving your order and report status. Please wait…',
     missingTitle: 'Missing session id',
     missingText: 'Please open this page via the redirect link after payment.',
     timeoutTitle: 'Polling timed out',
     timeoutText: 'The order is not finalized yet, it may still be processing. Try reopening this link in a moment.',
     errorTitle: 'Failed to load',
+    errorText: 'Your order status could not be retrieved. Check your connection and retry, or reopen the original link later. This page cannot confirm whether payment succeeded; do not pay again because of this error.',
     retry: 'Retry',
   },
 };
@@ -218,7 +220,6 @@ function ResultBody() {
   const [sessionId, setSessionId] = useState(null);
   const [status, setStatus] = useState('init');
   const [data, setData] = useState(null);
-  const [errorMsg, setErrorMsg] = useState('');
   const [attempt, setAttempt] = useState(0);
   const [downloading, setDownloading] = useState(false);
   const timerRef = useRef(null);
@@ -305,7 +306,6 @@ function ResultBody() {
       } catch (err) {
         if (cancelledRef.current) return;
         if (count >= MAX_POLLS) {
-          setErrorMsg(err && err.message ? err.message : String(err));
           setStatus('error');
           return;
         }
@@ -322,7 +322,6 @@ function ResultBody() {
 
   const retry = () => {
     setStatus('init');
-    setErrorMsg('');
     setData(null);
     setAttempt(0);
     if (sessionId) {
@@ -470,7 +469,7 @@ function ResultBody() {
           <a href={formHref} className={styles.backLink}>&larr; {t.backForm}</a>
           <div className={styles.statusCard}>
             <h2 className={styles.statusTitle}>{t.errorTitle}</h2>
-            <p className={styles.statusText}>{errorMsg}</p>
+            <p className={styles.statusText}>{t.errorText}</p>
             <button className={styles.retryBtn} onClick={retry}>{t.retry}</button>
           </div>
         </div>

--- a/src/pages/submit-dp.jsx
+++ b/src/pages/submit-dp.jsx
@@ -19,6 +19,7 @@ import {
 import SignInButtons from '@site/src/lib/auth/SignInButtons';
 import { startOAuth } from '@site/src/lib/auth/oauth';
 import { STORAGE_KEYS } from '../lib/storage-keys';
+import { localizedInternalPath } from '@site/src/lib/seo/localizedAlternates.mjs';
 import styles from './submit-dp.module.css';
 
 // ---------- i18n ----------
@@ -558,12 +559,13 @@ function Inner() {
       if (el) el.focus({ preventScroll: false });
       return;
     }
+    setFieldErrors({});
+    setMsg(null);
     if (!me) {
       setShowSignInModal(true);
       return;
     }
     setSavingApplicant(true);
-    setMsg(null);
     try {
       const payload = formToPayload(form);
       if (applicant) {
@@ -587,7 +589,7 @@ function Inner() {
         <div className={styles.headerTop}>
           <div>
             <h1>{t.pageTitle}</h1>
-            <a href="/datapoints" className={styles.backLink}>{t.browseAll}</a>
+            <a href={localizedInternalPath('/datapoints', locale)} className={styles.backLink}>{t.browseAll}</a>
           </div>
           {me ? (
             <span className={styles.meBadge}>
@@ -1158,7 +1160,7 @@ function DpAddArea({ t, locale, applicantId }) {
           <button className={styles.primaryBtn} disabled={saving} onClick={submit}>
             {saving ? t.btnSubmittingDp : t.btnSubmitDp}
           </button>
-          <a className={styles.secondaryLink} href="/my-dp">{t.viewMyDp}</a>
+          <a className={styles.secondaryLink} href={localizedInternalPath('/my-dp', locale)}>{t.viewMyDp}</a>
         </div>
       </div>
 

--- a/src/pages/tracker.jsx
+++ b/src/pages/tracker.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react'
 import Layout from '@theme/Layout';
 import Head from '@docusaurus/Head';
 import Translate, { translate } from '@docusaurus/Translate';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import {
   DndContext,
   DragOverlay,
@@ -19,6 +20,9 @@ import {
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { STORAGE_KEYS } from '../lib/storage-keys';
+import { localizedInternalPath } from '../lib/seo/localizedAlternates.mjs';
+import { MAX_BACKUP_BYTES, parseTrackerBackup, TRACKER_BACKUP_KEY } from '../lib/tracker/backup.mjs';
+import { attachDialogBehavior } from '../lib/tracker/dialog.mjs';
 import styles from './tracker.module.css';
 
 function getColumns() {
@@ -53,6 +57,14 @@ const COLUMN_IDS = ['reach', 'match', 'target', 'safety'];
 // ============ Helpers ============
 function genId() {
   return Date.now().toString(36) + Math.random().toString(36).slice(2, 8);
+}
+
+function useDialog(onClose) {
+  const dialogRef = useRef(null);
+  const closeRef = useRef(onClose);
+  closeRef.current = onClose;
+  useEffect(() => attachDialogBehavior(dialogRef.current, () => closeRef.current()), []);
+  return dialogRef;
 }
 
 function daysUntil(dateStr) {
@@ -139,6 +151,7 @@ function SortableCard({ card, onEdit, onDelete }) {
 
 // Card display (shared between sortable and overlay)
 function CardContent({ card, onEdit, onDelete }) {
+  const {i18n: {currentLocale}} = useDocusaurusContext();
   const days = daysUntil(card.deadline);
   const progress = computeProgress(card);
   const lorsDone = card.lors.filter(l => l.done).length;
@@ -216,7 +229,7 @@ function CardContent({ card, onEdit, onDelete }) {
       </div>
       {card.slug && (
         <a
-          href={card.slug}
+          href={localizedInternalPath(card.slug, currentLocale)}
           className={styles.programLink}
           onClick={(e) => e.stopPropagation()}
         >
@@ -272,9 +285,10 @@ function KanbanColumn({ column, cards, onAddCard, onEditCard, onDeleteCard }) {
 }
 
 // Add/Edit Card Modal
-function CardModal({ card, columns, essayStatuses, onSave, onClose }) {
+function CardModal({ card, initialCard, columns, essayStatuses, onSave, onClose }) {
+  const dialogRef = useDialog(onClose);
   const [form, setForm] = useState(
-    card || makeEmptyCard('reach')
+    card || initialCard || makeEmptyCard('reach')
   );
 
   const set = (key, val) => setForm((f) => ({ ...f, [key]: val }));
@@ -306,14 +320,14 @@ function CardModal({ card, columns, essayStatuses, onSave, onClose }) {
 
   return (
     <div className={styles.modalOverlay} onClick={onClose}>
-      <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
+      <div ref={dialogRef} role="dialog" aria-modal="true" aria-labelledby="tracker-card-title" tabIndex={-1} className={styles.modal} onClick={(e) => e.stopPropagation()}>
         <div className={styles.modalHeader}>
-          <h3 className={styles.modalTitle}>
+          <h3 id="tracker-card-title" className={styles.modalTitle}>
             {card
               ? translate({ id: 'tracker.modal.editTitle', message: '编辑项目' })
               : translate({ id: 'tracker.modal.addTitle', message: '添加自定义项目' })}
           </h3>
-          <button className={styles.modalClose} onClick={onClose}>&times;</button>
+          <button aria-label={translate({id: 'tracker.action.close', message: '关闭'})} className={styles.modalClose} onClick={onClose}>&times;</button>
         </div>
         <div className={styles.modalBody}>
           <div className={styles.formRow}>
@@ -322,6 +336,8 @@ function CardModal({ card, columns, essayStatuses, onSave, onClose }) {
                 <Translate id="tracker.form.schoolName">学校名称</Translate>
               </label>
               <input
+                data-dialog-initial-focus
+                aria-label={translate({id: 'tracker.form.schoolName', message: '学校名称'})}
                 className={styles.formInput}
                 value={form.school}
                 onChange={(e) => set('school', e.target.value)}
@@ -334,6 +350,7 @@ function CardModal({ card, columns, essayStatuses, onSave, onClose }) {
               </label>
               <input
                 className={styles.formInput}
+                aria-label={translate({id: 'tracker.form.programName', message: '项目名称'})}
                 value={form.program}
                 onChange={(e) => set('program', e.target.value)}
                 placeholder={translate({ id: 'tracker.form.programPlaceholder', message: '如: MSCS' })}
@@ -347,6 +364,7 @@ function CardModal({ card, columns, essayStatuses, onSave, onClose }) {
                 <Translate id="tracker.form.category">分类</Translate>
               </label>
               <select
+                aria-label={translate({id: 'tracker.form.category', message: '分类'})}
                 className={styles.formSelect}
                 value={form.column}
                 onChange={(e) => set('column', e.target.value)}
@@ -364,6 +382,7 @@ function CardModal({ card, columns, essayStatuses, onSave, onClose }) {
               </label>
               <input
                 type="date"
+                aria-label={translate({id: 'tracker.form.deadline', message: '截止日期'})}
                 className={styles.formInput}
                 value={form.deadline}
                 onChange={(e) => set('deadline', e.target.value)}
@@ -380,11 +399,13 @@ function CardModal({ card, columns, essayStatuses, onSave, onClose }) {
               <div key={idx} className={styles.lorRow}>
                 <input
                   type="checkbox"
+                  aria-label={lor.name}
                   className={styles.lorCheck}
                   checked={lor.done}
                   onChange={(e) => setLor(idx, 'done', e.target.checked)}
                 />
                 <input
+                  aria-label={translate({id: 'tracker.form.lorPlaceholder', message: '推荐人姓名'})}
                   className={styles.lorInput}
                   value={lor.name}
                   onChange={(e) => setLor(idx, 'name', e.target.value)}
@@ -419,6 +440,7 @@ function CardModal({ card, columns, essayStatuses, onSave, onClose }) {
               <div className={styles.formGroup}>
                 <label className={styles.formLabel}>TOEFL / IELTS</label>
                 <input
+                  aria-label="TOEFL / IELTS"
                   className={styles.formInput}
                   value={form.toefl}
                   onChange={(e) => set('toefl', e.target.value)}
@@ -428,6 +450,7 @@ function CardModal({ card, columns, essayStatuses, onSave, onClose }) {
               <div className={styles.formGroup}>
                 <label className={styles.formLabel}>GRE</label>
                 <input
+                  aria-label="GRE"
                   className={styles.formInput}
                   value={form.gre}
                   onChange={(e) => set('gre', e.target.value)}
@@ -464,6 +487,7 @@ function CardModal({ card, columns, essayStatuses, onSave, onClose }) {
               <Translate id="tracker.form.notes">备注</Translate>
             </label>
             <input
+              aria-label={translate({id: 'tracker.form.notes', message: '备注'})}
               className={styles.formInput}
               value={form.notes}
               onChange={(e) => set('notes', e.target.value)}
@@ -488,6 +512,7 @@ function CardModal({ card, columns, essayStatuses, onSave, onClose }) {
 
 // Library Import Modal
 function LibraryModal({ programs, existingIds, onImport, onClose }) {
+  const dialogRef = useDialog(onClose);
   const [search, setSearch] = useState('');
 
   const filtered = useMemo(() => {
@@ -503,35 +528,38 @@ function LibraryModal({ programs, existingIds, onImport, onClose }) {
 
   return (
     <div className={styles.modalOverlay} onClick={onClose}>
-      <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
+      <div ref={dialogRef} role="dialog" aria-modal="true" aria-labelledby="tracker-library-title" tabIndex={-1} className={styles.modal} onClick={(e) => e.stopPropagation()}>
         <div className={styles.modalHeader}>
-          <h3 className={styles.modalTitle}>
+          <h3 id="tracker-library-title" className={styles.modalTitle}>
             <Translate id="tracker.library.title">从项目库导入</Translate>
           </h3>
-          <button className={styles.modalClose} onClick={onClose}>&times;</button>
+          <button aria-label={translate({id: 'tracker.action.close', message: '关闭'})} className={styles.modalClose} onClick={onClose}>&times;</button>
         </div>
         <div className={styles.modalBody}>
           <input
             className={styles.librarySearch}
+            aria-label={translate({id: 'tracker.library.searchPlaceholder', message: '搜索学校或项目名称...' })}
             placeholder={translate({ id: 'tracker.library.searchPlaceholder', message: '搜索学校或项目名称...' })}
             value={search}
             onChange={(e) => setSearch(e.target.value)}
-            autoFocus
+            data-dialog-initial-focus
           />
           <div className={styles.libraryList}>
             {filtered.map((p) => {
               const added = existingIds.has(p.id);
               return (
-                <div
+                <button
+                  type="button"
+                  disabled={added}
                   key={p.id}
                   className={styles.libraryItem}
                   onClick={() => !added && onImport(p)}
                   style={added ? { opacity: 0.5 } : {}}
                 >
-                  <div className={styles.libraryItemInfo}>
+                  <span className={styles.libraryItemInfo}>
                     <span className={styles.libraryItemSchool}>{p.school}</span>
                     <span className={styles.libraryItemProgram}>{p.program}</span>
-                  </div>
+                  </span>
                   {added ? (
                     <span className={styles.libraryItemAdded}>
                       <Translate id="tracker.library.added">已添加</Translate>
@@ -539,7 +567,7 @@ function LibraryModal({ programs, existingIds, onImport, onClose }) {
                   ) : (
                     <span className={styles.libraryItemTier}>{p.tier}</span>
                   )}
-                </div>
+                </button>
               );
             })}
             {filtered.length === 0 && (
@@ -555,17 +583,18 @@ function LibraryModal({ programs, existingIds, onImport, onClose }) {
 }
 
 // Confirm dialog
-function ConfirmDialog({ message, onConfirm, onCancel }) {
+function ConfirmDialog({ message, onConfirm, onCancel, confirmLabel }) {
+  const dialogRef = useDialog(onCancel);
   return (
     <div className={styles.confirmOverlay} onClick={onCancel}>
-      <div className={styles.confirmBox} onClick={(e) => e.stopPropagation()}>
-        <p className={styles.confirmText}>{message}</p>
+      <div ref={dialogRef} role="alertdialog" aria-modal="true" aria-labelledby="tracker-confirm-message" tabIndex={-1} className={styles.confirmBox} onClick={(e) => e.stopPropagation()}>
+        <p id="tracker-confirm-message" className={styles.confirmText}>{message}</p>
         <div className={styles.confirmBtns}>
           <button className={styles.confirmCancel} onClick={onCancel}>
             <Translate id="tracker.action.cancel">取消</Translate>
           </button>
           <button className={styles.confirmDelete} onClick={onConfirm}>
-            <Translate id="tracker.action.confirmDelete">删除</Translate>
+            {confirmLabel || <Translate id="tracker.action.confirmDelete">删除</Translate>}
           </button>
         </div>
       </div>
@@ -575,11 +604,18 @@ function ConfirmDialog({ message, onConfirm, onCancel }) {
 
 // ============ Main Page ============
 export default function TrackerPage() {
+  const {i18n: {currentLocale}} = useDocusaurusContext();
   const COLUMNS = getColumns();
   const ESSAY_STATUSES = getEssayStatuses();
   const SORT_OPTIONS = getSortOptions();
 
   const [cards, setCards] = useState([]);
+  const [storageStatus, setStorageStatus] = useState('loading');
+  const [storageError, setStorageError] = useState(null);
+  const [pendingImport, setPendingImport] = useState(null);
+  const [canUndoImport, setCanUndoImport] = useState(false);
+  const [showUndoConfirm, setShowUndoConfirm] = useState(false);
+  const [importMessage, setImportMessage] = useState(null);
   const [programs, setPrograms] = useState([]);
   const [activeCard, setActiveCard] = useState(null);
   const [showAddModal, setShowAddModal] = useState(null); // null or column id
@@ -593,23 +629,24 @@ export default function TrackerPage() {
   useEffect(() => {
     try {
       const saved = localStorage.getItem(STORAGE_KEYS.trackerData);
-      if (saved) {
-        const parsed = JSON.parse(saved);
-        if (Array.isArray(parsed)) setCards(parsed);
-      }
+      if (saved) setCards(parseTrackerBackup(saved));
+      setCanUndoImport(localStorage.getItem(TRACKER_BACKUP_KEY) !== null);
+      setStorageStatus('ready');
     } catch (e) {
-      // ignore
+      setStorageStatus('error');
+      setStorageError(translate({id: 'tracker.storage.loadFailed', message: '无法读取当前清单，原始数据已保留。请先导出原始备份，再尝试导入有效备份。'}));
     }
   }, []);
 
   // Save to localStorage
   useEffect(() => {
+    if (storageStatus !== 'ready') return;
     try {
       localStorage.setItem(STORAGE_KEYS.trackerData, JSON.stringify(cards));
     } catch (e) {
-      // ignore
+      setStorageError(translate({id: 'tracker.storage.saveFailed', message: '浏览器未能保存清单，请导出备份，避免刷新后丢失更改。'}));
     }
-  }, [cards]);
+  }, [cards, storageStatus]);
 
   // Fetch program library
   useEffect(() => {
@@ -768,7 +805,8 @@ export default function TrackerPage() {
 
   // Export/Import JSON
   const handleExport = () => {
-    const blob = new Blob([JSON.stringify(cards, null, 2)], {
+    const data = storageStatus === 'error' ? localStorage.getItem(STORAGE_KEYS.trackerData) : JSON.stringify(cards, null, 2);
+    const blob = new Blob([data], {
       type: 'application/json',
     });
     const url = URL.createObjectURL(blob);
@@ -782,19 +820,75 @@ export default function TrackerPage() {
   const handleImportFile = (e) => {
     const file = e.target.files?.[0];
     if (!file) return;
+    setImportMessage(null);
+    setPendingImport(null);
+    e.target.value = '';
+    const failed = () => setImportMessage(translate({id: 'tracker.import.invalid', message: '导入失败：请使用完整有效的清单 JSON 备份（不超过 10 MB）。原清单未更改。'}));
+    if (file.size > MAX_BACKUP_BYTES) { failed(); return; }
     const reader = new FileReader();
     reader.onload = (ev) => {
       try {
-        const data = JSON.parse(ev.target.result);
-        if (Array.isArray(data)) {
-          setCards(data);
-        }
+        setPendingImport(parseTrackerBackup(ev.target.result));
       } catch (err) {
-        alert(translate({ id: 'tracker.alert.importFailed', message: '导入失败: JSON 格式无效' }));
+        failed();
       }
     };
+    reader.onerror = failed;
     reader.readAsText(file);
-    e.target.value = '';
+  };
+
+  const confirmImport = () => {
+    let previousUndoBackup;
+    let undoBackupChanged = false;
+    try {
+      // Keep the previous raw value, including an unreadable legacy backup, before replacing it.
+      const previous = storageStatus === 'ready'
+        ? JSON.stringify(cards)
+        : localStorage.getItem(STORAGE_KEYS.trackerData) ?? '[]';
+      previousUndoBackup = localStorage.getItem(TRACKER_BACKUP_KEY);
+      localStorage.setItem(TRACKER_BACKUP_KEY, previous);
+      undoBackupChanged = true;
+      localStorage.setItem(STORAGE_KEYS.trackerData, JSON.stringify(pendingImport));
+      setCards(pendingImport);
+      setStorageStatus('ready');
+      setStorageError(null);
+      setCanUndoImport(true);
+      setPendingImport(null);
+      setImportMessage(translate({id: 'tracker.import.success', message: '导入完成。已保留导入前的清单，可撤销最近一次导入。'}));
+    } catch {
+      if (undoBackupChanged) {
+        try {
+          // The main write failed: restore the undo history as well as retaining the current list.
+          if (previousUndoBackup === null) localStorage.removeItem(TRACKER_BACKUP_KEY);
+          else localStorage.setItem(TRACKER_BACKUP_KEY, previousUndoBackup);
+        } catch {
+          setCanUndoImport(false);
+          setImportMessage(translate({id: 'tracker.import.rollbackFailed', message: '导入未完成，当前清单未更改。但浏览器也无法恢复之前的撤销备份，本次会话已停用撤销入口。请立即导出当前清单；不要依赖现有撤销备份。'}));
+          return;
+        }
+      }
+      setImportMessage(translate({id: 'tracker.import.storageFailed', message: '浏览器无法保存导入前的备份或新清单，导入未完成。原清单未更改。'}));
+    }
+  };
+
+  const undoImport = () => {
+    try {
+      const previous = localStorage.getItem(TRACKER_BACKUP_KEY);
+      if (previous === null) return;
+      // Validate before restoring. An unreadable legacy value remains available for export.
+      let restored;
+      try { restored = parseTrackerBackup(previous); } catch { restored = null; }
+      localStorage.setItem(STORAGE_KEYS.trackerData, previous);
+      setCards(restored || []);
+      setStorageStatus(restored ? 'ready' : 'error');
+      setStorageError(restored ? null : translate({id: 'tracker.storage.loadFailed', message: '无法读取当前清单，原始数据已保留。请先导出原始备份，再尝试导入有效备份。'}));
+      setCanUndoImport(false);
+      localStorage.removeItem(TRACKER_BACKUP_KEY);
+      setImportMessage(translate({id: 'tracker.import.undone', message: '已恢复导入前的清单。'}));
+      setShowUndoConfirm(false);
+    } catch {
+      setImportMessage(translate({id: 'tracker.storage.saveFailed', message: '浏览器未能保存清单，请导出备份，避免刷新后丢失更改。'}));
+    }
   };
 
   const totalCards = cards.length;
@@ -816,19 +910,22 @@ export default function TrackerPage() {
       <div className={styles.pageWrapper}>
         {/* Top bar */}
         <div className={styles.topBar}>
-          <a href="/" className={styles.backLink}>
+          <a href={localizedInternalPath('/', currentLocale)} className={styles.backLink}>
             &larr; <Translate id="tracker.nav.backHome">返回首页</Translate>
           </a>
           <div className={styles.topBarRight}>
-            <span className={styles.topBarLink} onClick={handleExport}>
+            <button type="button" className={styles.topBarLink} onClick={handleExport} disabled={storageStatus === 'loading'}>
               &#128190; {translate({ id: 'tracker.action.export', message: '导出数据' })}
-            </span>
-            <span
+            </button>
+            <button type="button"
               className={styles.topBarLink}
               onClick={() => fileInputRef.current?.click()}
             >
               &#128194; {translate({ id: 'tracker.action.import', message: '导入数据' })}
-            </span>
+            </button>
+            {canUndoImport && <button type="button" className={styles.topBarLink} onClick={() => setShowUndoConfirm(true)}>
+              <Translate id="tracker.import.undo">撤销最近导入</Translate>
+            </button>}
             <input
               ref={fileInputRef}
               type="file"
@@ -838,6 +935,9 @@ export default function TrackerPage() {
             />
           </div>
         </div>
+
+        {storageError && <p role="alert" className={styles.notice}>{storageError}</p>}
+        {importMessage && <p role="status" className={styles.notice}>{importMessage}</p>}
 
         {/* Header */}
         <div className={styles.header}>
@@ -862,6 +962,7 @@ export default function TrackerPage() {
             </div>
             <select
               className={styles.sortSelect}
+              aria-label={translate({id: 'tracker.sort.label', message: '分类方式:'})}
               value={sortBy}
               onChange={(e) => setSortBy(e.target.value)}
             >
@@ -877,6 +978,7 @@ export default function TrackerPage() {
           </div>
           <div className={styles.toolbarRight}>
             <button
+              disabled={storageStatus !== 'ready'}
               className={`${styles.actionBtn} ${styles.importBtn}`}
               onClick={handleAddCustomCard}
             >
@@ -886,7 +988,7 @@ export default function TrackerPage() {
         </div>
 
         {/* Kanban Board */}
-        <DndContext
+        {storageStatus === 'ready' && <DndContext
           sensors={sensors}
           collisionDetection={closestCorners}
           onDragStart={handleDragStart}
@@ -912,15 +1014,16 @@ export default function TrackerPage() {
               </div>
             ) : null}
           </DragOverlay>
-        </DndContext>
+        </DndContext>}
 
         {/* Modals */}
         {showAddModal && (
           <CardModal
             card={null}
+            initialCard={showAddModal}
             columns={COLUMNS}
             essayStatuses={ESSAY_STATUSES}
-            onSave={(card) => handleSaveNewCard({ ...card, column: showAddModal.column })}
+            onSave={handleSaveNewCard}
             onClose={() => setShowAddModal(null)}
           />
         )}
@@ -948,6 +1051,18 @@ export default function TrackerPage() {
             onCancel={() => setShowConfirm(null)}
           />
         )}
+        {pendingImport && <ConfirmDialog
+          message={translate({id: 'tracker.import.confirm', message: '此备份包含 {count} 个项目，将替换当前 {current} 个项目（不是合并）。导入前的清单会保留为可撤销备份，覆盖上一次导入备份。是否继续？'}, {count: pendingImport.length, current: cards.length})}
+          confirmLabel={translate({id: 'tracker.import.replace', message: '确认替换'})}
+          onConfirm={confirmImport}
+          onCancel={() => setPendingImport(null)}
+        />}
+        {showUndoConfirm && <ConfirmDialog
+          message={translate({id: 'tracker.import.undoConfirm', message: '恢复最近一次导入前的清单？导入后的编辑将被替换。请先导出当前清单以保留这些编辑。'})}
+          confirmLabel={translate({id: 'tracker.import.restore', message: '恢复旧清单'})}
+          onConfirm={undoImport}
+          onCancel={() => setShowUndoConfirm(false)}
+        />}
       </div>
     </Layout>
   );

--- a/src/pages/tracker.module.css
+++ b/src/pages/tracker.module.css
@@ -9,6 +9,13 @@
   padding: 24px 32px 48px;
 }
 
+.notice {
+  padding: 12px 16px;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 8px;
+  color: var(--ifm-font-color-base);
+}
+
 [data-theme='dark'] .pageWrapper {
   background: linear-gradient(135deg, #1e1e1e 0%, #252525 50%, #1e1e1e 100%);
 }
@@ -684,6 +691,11 @@
 }
 
 .libraryItem {
+  width: 100%;
+  border: 0;
+  background: transparent;
+  text-align: left;
+  font: inherit;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -944,6 +956,8 @@
   align-items: center;
   justify-content: space-between;
   margin-bottom: 12px;
+  flex-wrap: wrap;
+  gap: 10px;
 }
 
 .backLink {
@@ -967,9 +981,14 @@
   display: flex;
   align-items: center;
   gap: 12px;
+  flex-wrap: wrap;
 }
 
 .topBarLink {
+  border: 0;
+  padding: 0;
+  background: transparent;
+  font-family: inherit;
   font-size: 0.82rem;
   color: #80652e;
   text-decoration: none;

--- a/src/theme/NavbarItem/LocaleDropdownNavbarItem/index.js
+++ b/src/theme/NavbarItem/LocaleDropdownNavbarItem/index.js
@@ -10,6 +10,7 @@ import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import {useAlternatePageUtils} from '@docusaurus/theme-common/internal';
 import {translate} from '@docusaurus/Translate';
 import {useLocation} from '@docusaurus/router';
+import useIsBrowser from '@docusaurus/useIsBrowser';
 import DropdownNavbarItem from '@theme/NavbarItem/DropdownNavbarItem';
 import IconLanguage from '@theme/Icon/Language';
 import {localizedAlternateUrl} from '../../../lib/seo/localizedAlternates.mjs';
@@ -28,6 +29,7 @@ export default function LocaleDropdownNavbarItem({
   } = useDocusaurusContext();
   const alternatePageUtils = useAlternatePageUtils();
   const {pathname, search, hash} = useLocation();
+  const isBrowser = useIsBrowser();
 
   const localeItems = locales.map((locale) => {
     const localizedPath = localizedAlternateUrl({
@@ -40,7 +42,14 @@ export default function LocaleDropdownNavbarItem({
       }),
     });
     const baseTo = `pathname://${localizedPath}`;
-    const to = `${baseTo}${search}${hash}${queryString}`;
+    // Static HTML cannot know the visitor's query/hash. Match that HTML during
+    // hydration, then update the link so React does not leave a stale SSR href.
+    const liveSearch = isBrowser ? search : '';
+    const extraQuery = queryString.replace(/^[?&]/, '');
+    const combinedSearch = extraQuery
+      ? `${liveSearch || '?'}${liveSearch ? '&' : ''}${extraQuery}`
+      : liveSearch;
+    const to = `${baseTo}${combinedSearch}${isBrowser ? hash : ''}`;
     return {
       label: localeConfigs[locale].label,
       lang: localeConfigs[locale].htmlLang,


### PR DESCRIPTION
## 本次修复

处理两轮端到端验收确认的 F01–F10：

- 转码攻略中英文双向切换使用实际路径，并删除对应 3 条旧 SEO 豁免。
- 首次加载后的语言菜单恢复 query/hash；DP 筛选通过 Router 更新，切语言保留筛选与结果页订单参数。
- 英文清单首页/项目详情、DP/提交/我的 DP 链接保持英文。
- 补全英文过往案例，保留 7 张原图；同步已有中文咨询服务与早鸟期限，修正文案星号和相邻页标签。
- 清单新增保存用户选择的分类；弹窗支持 Esc、焦点循环和返回触发按钮。
- 导入先验证再确认替换；无效导入不动原数据；保留撤销备份，刷新后可恢复。修复初次加载空写，以及后续导入失败覆盖前次撤销备份的问题。
- DP 加载/失败/真实空结果明确区分，提供重试并标注统计来源；必填校验通过后清除旧错误；结果页不再未经确认声称 Stripe 正在确认付款。

## 验证

- 54 项原有及扩展 SEO/Analytics/迁移/GPA 检查通过。
- 33 项 UX 回归通过，并接入 CI：真实页面回调、语言菜单、导入失败/撤销、焦点边界和 DP 错误状态。
- 中英文生产构建无 warning；SEO audit 204 个可索引页面、204 个 sitemap URL 通过，历史豁免从 161 降至 158。
- Chrome 隔离环境实际点击验证转码双向语言切换、订单/DP 参数保留、英文项目详情、无效导入保护、确认/取消/刷新后撤销及 Esc 焦点返回。

## 边界

测试时通过本地 CSP 阻断生产接口和正式 GA4，只使用合成数据。未对真实账号、DP 或订单写入，未测试真实支付/OAuth 成功，不重启已下线的选校服务，不更改中文默认语言策略。测试报告和临时夹具不提交进项目。
