### PR TITLE
恢复首页原正文并将侧栏改为 Intro

### DIFF
--- a/docs/intro.mdx
+++ b/docs/intro.mdx
@@ -2,38 +2,18 @@
 id: intro
 title: 北美MSCS申请
 slug: /
-description: CS Grad 中文首页：面向中国大陆及北美本科申请者，提供北美 CS/MSCS 项目介绍、录取数据、申请时间线与辅导服务，帮助你结合背景、课程、费用和职业目标选校。
+description: CS Grad 提供北美 CS、MSCS 及相关硕士项目介绍、申请数据和选校参考，帮助申请者结合课程、成本与就业方向评估项目。
 hide_title: true
 ---
 
 import VisitorGeoMap from '@site/src/components/VisitorGeoMap';
-import Head from '@docusaurus/Head';
 
-<Head>
-  <script type="application/ld+json">{JSON.stringify({
-    '@context': 'https://schema.org',
-    '@type': 'WebSite',
-    '@id': 'https://csgrad.com/#website',
-    name: 'CS Grad',
-    alternateName: ['csgrad', 'CSGrad'],
-    url: 'https://csgrad.com/',
-    inLanguage: ['zh-Hans', 'en'],
-  })}</script>
-</Head>
-
-# CS Grad：北美 CS/MSCS 申请与选校指南
-
-CS Grad 帮助中国大陆和北美本科申请者了解北美计算机及相关硕士项目。你可以查看项目介绍、参考历史录取数据，并结合自己的背景、课程偏好、预算和职业目标制定申请计划。
-
-<strong>从这里开始：</strong>浏览侧栏项目介绍、[查询录取数据](/datapoints)、[整理申请清单](/tracker)，或[了解申请辅导](/找我辅导)。
-
-<p><a href="https://csgrad.com/en/" hrefLang="en" lang="en">English version</a></p>
+# CS Grad：北美 MSCS 申请与选校指南
 
 ![License: CC BY-NC-SA 4.0](https://img.shields.io/badge/License-CC%20BY--NC--SA%204.0-lightgrey.svg)
 [![GitHub Repo stars](https://img.shields.io/github/stars/csms-apply/csgrad)](https://github.com/csms-apply/csgrad)
 
-<details>
-<summary>往期活动：2026 年 8 月 29 日 MSCS 申请趋势 Info Session</summary>
+:::tip 📬 Info Session 参会链接已发送
 
 Csgrad 27 Fall MSCS 申请趋势 Info Session 的 Google Meet 参会链接，已经发送到大家报名时填写的邮箱。
 
@@ -45,7 +25,7 @@ Csgrad 27 Fall MSCS 申请趋势 Info Session 的 Google Meet 参会链接，已
 
 如果收件箱里没有找到，请检查 **Spam / 垃圾邮件** 文件夹。
 
-</details>
+:::
 
 CS Grad 项目专注于北美 MSCS 申请，涵盖 CS、DS、EE、ECE、IS 等相关专业的介绍。Motivation 是帮助来自 **中国大陆** 和 **北美本科** 的申请者更高效地了解各项目的定位及其 **实际价值**。与侧重录取门槛（admission bar）排名的 Open CS App 不同，CS Grad 更关注 **项目的真实价值**，尤其是在北美 **SDE求职** 方面的帮助，而 **非单纯的录取难度**。
 

--- a/i18n/en/docusaurus-plugin-content-docs/current.json
+++ b/i18n/en/docusaurus-plugin-content-docs/current.json
@@ -47,8 +47,8 @@
     "message": "Useful Docs",
     "description": "The label for category 有用的文档 in sidebar tutorialSidebar"
   },
-  "sidebar.tutorialSidebar.doc.北美MSCS申请": {
-    "message": "MSCS Application Guide",
+  "sidebar.tutorialSidebar.doc.Intro": {
+    "message": "Intro",
     "description": "The label for the homepage in sidebar tutorialSidebar, linking to the doc intro"
   },
   "sidebar.tutorialSidebar.doc.转码项目合集": {

--- a/sidebars.js
+++ b/sidebars.js
@@ -20,7 +20,7 @@ const sidebars = {
     {
       type: 'doc',
       id: 'intro',
-      label: '北美MSCS申请',
+      label: 'Intro',
     },
 
     {


### PR DESCRIPTION
恢复中文首页改版前的正文和 Info Session 提示样式，保留现有页面标题「北美MSCS申请」及主标题「CS Grad：北美 MSCS 申请与选校指南」。首页侧边栏标签改为 Intro，并同步对应英文翻译键。

验证：已确认首页文件除保留的两个标题外与改版前版本完全一致；`git diff --check` 与 25 项 SEO 测试通过。完整双语构建及其余检查由 PR CI 执行。
