### PR TITLE
选校结果展示风险说明与补充主申候选

### DIFF
--- a/scripts/positioning-risk-display.test.cjs
+++ b/scripts/positioning-risk-display.test.cjs
@@ -1,0 +1,55 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+const React = require('react');
+const { renderToStaticMarkup } = require('react-dom/server');
+const { transformSync } = require('@babel/core');
+const filename = path.join(__dirname, '../src/pages/school-positioning-result.jsx');
+const source = fs.readFileSync(filename, 'utf8');
+const { code } = transformSync(source, {
+  filename, babelrc: false, configFile: false,
+  presets: [require.resolve('@babel/preset-react')],
+  plugins: [require.resolve('@babel/plugin-transform-modules-commonjs')],
+});
+const exportsForTest = {};
+vm.runInNewContext(code, {
+  exports: exportsForTest,
+  require(name) {
+    if (name === 'react') return React;
+    if (name.endsWith('.module.css')) return { __esModule: true, default: new Proxy({}, { get: (_, key) => key }) };
+    if (name.startsWith('@')) return {};
+    throw new Error(`Unexpected import: ${name}`);
+  },
+});
+const { RiskNotice, ReviewedAlternatives } = exportsForTest;
+const render = (component, props) => renderToStaticMarkup(React.createElement(component, props));
+
+test('uncalibrated policy text is visible and escaped', () => {
+  const html = render(RiskNotice, { locale: 'zh-Hans', policy: { calibrated: false, caveat: '风险未校准 <script>unsafe</script>' } });
+  assert.match(html, /风险未校准/);
+  assert.ok(!html.includes('<script>'));
+});
+test('legacy responses retain a meaningful localized risk explanation', () => {
+  assert.match(render(RiskNotice, { locale: 'zh-Hans' }), /不保证录取/);
+  assert.match(render(RiskNotice, { locale: 'en' }), /not personal admission probabilities/);
+  assert.equal(render(ReviewedAlternatives, { locale: 'en' }), '');
+});
+test('additional match candidates display reason and link, excluding other buckets', () => {
+  const html = render(ReviewedAlternatives, { locale: 'zh-Hans', items: [
+    { bucket: 'match', school: 'Example MCS', reason: '需要进一步审核方向', doc: '/A/Example MCS' },
+    { bucket: 'safety', school: 'Wrong bucket' }, null,
+  ] });
+  assert.match(html, /补充主申候选/); assert.match(html, /Example MCS/);
+  assert.match(html, /需要进一步审核方向/); assert.match(html, /href="\/A\/Example%20MCS"/);
+  assert.ok(!html.includes('Wrong bucket'));
+});
+test('risk and alternatives are part of the same DOM subtree exported to PDF', () => {
+  const start = source.indexOf('<div ref={reportRef}');
+  const footer = source.indexOf('<div className={styles.reportFooter}', start);
+  const report = source.slice(start, footer);
+  assert.match(report, /<RiskNotice policy={data.riskPolicy}/);
+  assert.match(report, /<ReviewedAlternatives items={data.reviewedAlternatives}/);
+  assert.match(source, /\.from\(reportRef.current\)/);
+});

--- a/src/pages/school-positioning-result.jsx
+++ b/src/pages/school-positioning-result.jsx
@@ -44,10 +44,15 @@ const COPY = {
     consultPerk: '🎁 你这次付的选校报告费用，会全额从后续辅导费里减免。',
     bucketReach: '冲刺',
     bucketReachSub: 'Reach',
-    bucketMatch: '匹配',
+    bucketMatch: '主申',
     bucketMatchSub: 'Match',
-    bucketSafety: '保底',
-    bucketSafetySub: 'Safety',
+    bucketSafety: '备选',
+    bucketSafetySub: 'Alternatives',
+    riskTitle: '申请风险说明',
+    riskFallback: '这些分组尚未经过录取风险校准，不能理解为个人录取概率；主申和备选项目也不保证录取。',
+    reviewedTitle: '补充主申候选',
+    reviewedSub: 'Additional match candidates',
+    reviewedDescription: '以下项目已从原备选范围调整为主申候选，本次主申名单未列入；可结合课程、方向与申请预算进一步筛选。',
     emptyBucket: '该档暂无推荐',
     viewDetail: '了解详情',
     pendingTitle: '正在获取订单状态',
@@ -89,8 +94,13 @@ const COPY = {
     bucketReachSub: 'Reach',
     bucketMatch: 'Match',
     bucketMatchSub: 'Match',
-    bucketSafety: 'Safety',
-    bucketSafetySub: 'Safety',
+    bucketSafety: 'Alternatives',
+    bucketSafetySub: 'Alternatives',
+    riskTitle: 'Application risk',
+    riskFallback: 'These groups have not been calibrated against admission risk and are not personal admission probabilities. Match and alternative programs do not guarantee admission.',
+    reviewedTitle: 'Additional match candidates',
+    reviewedSub: 'For further consideration',
+    reviewedDescription: 'These programs were moved from the alternative group to match candidates and are additional to this report’s main list. Review their courses, focus and application cost before choosing.',
     emptyBucket: 'No picks in this bucket',
     viewDetail: 'Learn more',
     pendingTitle: 'Checking order status',
@@ -209,6 +219,30 @@ function Bucket({ items, title, subtitle, variantClass, locale, t }) {
         )}
       </div>
     </div>
+  );
+}
+
+export function RiskNotice({ policy, locale }) {
+  const t = COPY[pickLocale(locale)];
+  const caveat = getLabel(policy?.caveat, locale);
+  return (
+    <aside className={`${styles.warningItem} ${styles.warningInfo} ${styles.riskNotice}`} aria-label={t.riskTitle}>
+      <strong>{t.riskTitle}</strong>
+      <p>{policy?.calibrated === false && caveat ? caveat : t.riskFallback}</p>
+    </aside>
+  );
+}
+
+export function ReviewedAlternatives({ items, locale }) {
+  const t = COPY[pickLocale(locale)];
+  const list = Array.isArray(items) ? items.filter(s => s && s.bucket === 'match') : [];
+  if (!list.length) return null;
+  return (
+    <section className={styles.reviewedAlternatives} aria-label={t.reviewedTitle}>
+      <p className={styles.summary}>{t.reviewedDescription}</p>
+      <Bucket items={list} title={t.reviewedTitle} subtitle={t.reviewedSub}
+        variantClass={styles.bucketMatch} locale={locale} t={t} />
+    </section>
   );
 }
 
@@ -379,6 +413,7 @@ function ResultBody() {
               <h1 className={styles.tierName}>{tierName}</h1>
               {summary && <p className={styles.summary}>{summary}</p>}
             </div>
+            <RiskNotice policy={data.riskPolicy} locale={locale} />
             <AdviceSection advice={data.llmAdvice} t={t} />
             {Array.isArray(data.warnings) && data.warnings.length > 0 && (
               <div className={styles.warningList}>
@@ -418,6 +453,7 @@ function ResultBody() {
                 t={t}
               />
             </div>
+            <ReviewedAlternatives items={data.reviewedAlternatives} locale={locale} />
             {data.phdRecommended && Array.isArray(data.phdRecommended.schools) && data.phdRecommended.schools.length > 0 && (
               <div className={styles.phdSection}>
                 <div className={styles.phdHeader}>

--- a/src/pages/school-positioning-result.module.css
+++ b/src/pages/school-positioning-result.module.css
@@ -737,3 +737,23 @@
 .retryBtn:hover {
   background: #b8985d;
 }
+
+.riskNotice {
+  margin: 20px 0;
+  break-inside: avoid;
+}
+
+.riskNotice p {
+  margin: 6px 0 0;
+}
+
+.reviewedAlternatives {
+  margin-top: 24px;
+}
+
+@media print {
+  .riskNotice,
+  .reviewedAlternatives .schoolCard {
+    break-inside: avoid;
+  }
+}


### PR DESCRIPTION
选校风险调整后，原保底项目可能转为主申，但未进入主列表的补充候选此前无法在结果页查看。本改动展示补充主申项目、理由与详情链接，并说明风险分组尚未校准、不能保证录取。

新增内容位于报告导出容器内，打印和PDF包含同样信息；兼容旧版响应。仅复用现有布局与样式，未修改表单或数据。

验证：4项Babel编译与React渲染检查通过，覆盖中英文、新旧响应、链接/文字转义及PDF容器。后端配套增加riskPolicy与reviewedAlternatives。
