### PR TITLE
Launch English positioning while keeping Chinese entry offline

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -67,6 +67,7 @@ const config = {
           ignorePatterns: [
             '**/datapoints submit',
             '**/my-dp',
+            '**/school-positioning',
             '**/school-positioning-result',
             '**/submit-dp',
           ],

--- a/scripts/global-positioning.test.cjs
+++ b/scripts/global-positioning.test.cjs
@@ -124,7 +124,8 @@ test('only English launches the form; Chinese and unsupported locales keep the o
     const html = render(page.default, {});
     if (locale === 'en') {
       assert.match(html, /data-form-entry="enabled"/);
-      assert.doesNotMatch(html, /temporarily offline|name="robots"/);
+      assert.doesNotMatch(html, /temporarily offline/);
+      assert.match(html, /name="robots" content="noindex"/);
     } else {
       assert.match(html, /选校定位暂时下线/);
       assert.match(html, /name="robots" content="noindex"/);

--- a/scripts/global-positioning.test.cjs
+++ b/scripts/global-positioning.test.cjs
@@ -6,12 +6,13 @@ const vm = require('node:vm');
 const React = require('react');
 const { renderToStaticMarkup } = require('react-dom/server');
 const { transformFileSync } = require('@babel/core');
-function load(file) {
+function load(file, mocks = {}) {
   const filename = path.join(__dirname, '..', file);
   const { code } = transformFileSync(filename, { babelrc: false, configFile: false,
     presets: [require.resolve('@babel/preset-react')], plugins: [require.resolve('@babel/plugin-transform-modules-commonjs')] });
   const out = {};
   vm.runInNewContext(code, { exports: out, require(name) {
+    if (Object.hasOwn(mocks, name)) return mocks[name];
     if (name === 'react') return React;
     if (name.endsWith('.module.css')) return { __esModule: true, default: new Proxy({}, { get: (_, k) => k }) };
     if (name.includes('profile-schema')) return schema;
@@ -110,4 +111,24 @@ test('employment outside the US is distinct from working in China', () => {
   assert.equal(goals.find(o => o.value === 'cn-job').label.en, 'Work in China');
   const profile = { ...form.buildInitialProfile(fields), careerGoal: 'other-job' };
   assert.equal(form.positioningPayload(profile, fields, 'en').careerGoal, 'other-job');
+});
+
+test('only English launches the form; Chinese and unsupported locales keep the offline notice', () => {
+  for (const locale of ['en', 'zh-Hans', 'fr']) {
+    const page = load('src/pages/school-positioning.jsx', {
+      '@docusaurus/useDocusaurusContext': { __esModule: true, default: () => ({ i18n: { currentLocale: locale } }) },
+      '@theme/Layout': { __esModule: true, default: ({ children }) => React.createElement('main', null, children) },
+      '@docusaurus/Head': { __esModule: true, default: ({ children }) => React.createElement(React.Fragment, null, children) },
+      '@docusaurus/BrowserOnly': { __esModule: true, default: () => React.createElement('div', { 'data-form-entry': 'enabled' }) },
+    });
+    const html = render(page.default, {});
+    if (locale === 'en') {
+      assert.match(html, /data-form-entry="enabled"/);
+      assert.doesNotMatch(html, /temporarily offline|name="robots"/);
+    } else {
+      assert.match(html, /选校定位暂时下线/);
+      assert.match(html, /name="robots" content="noindex"/);
+      assert.doesNotMatch(html, /data-form-entry/);
+    }
+  }
 });

--- a/src/pages/school-positioning.jsx
+++ b/src/pages/school-positioning.jsx
@@ -8,7 +8,6 @@ import { WORKER_BASE_URL } from '@site/src/lib/positioning/api';
 import {trackSeoEvent} from '@site/src/lib/analytics/events.mjs';
 import styles from './school-positioning.module.css';
 
-const POSITIONING_AVAILABLE = false;
 
 const COPY = {
   'zh-Hans': {
@@ -694,8 +693,9 @@ export default function SchoolPositioningPage() {
   const { i18n } = useDocusaurusContext();
   const locale = pickLocale(i18n.currentLocale);
   const t = COPY[locale];
-  const pageTitle = POSITIONING_AVAILABLE ? t.pageTitle : t.offlineTitle;
-  const pageDesc = POSITIONING_AVAILABLE ? t.pageDesc : t.offlineLead;
+  const positioningAvailable = locale === 'en';
+  const pageTitle = positioningAvailable ? t.pageTitle : t.offlineTitle;
+  const pageDesc = positioningAvailable ? t.pageDesc : t.offlineLead;
   return (
     <Layout title={pageTitle} description={pageDesc}>
       <Head>
@@ -703,9 +703,9 @@ export default function SchoolPositioningPage() {
         <meta property="og:title" content={pageTitle} />
         <meta property="og:description" content={pageDesc} />
         <meta property="og:type" content="website" />
-        {!POSITIONING_AVAILABLE && <meta name="robots" content="noindex" />}
+        {!positioningAvailable && <meta name="robots" content="noindex" />}
       </Head>
-      {POSITIONING_AVAILABLE ? (
+      {positioningAvailable ? (
         <BrowserOnly fallback={<div className={styles.pageWrapper} />}>
           {() => <FormBody />}
         </BrowserOnly>

--- a/src/pages/school-positioning.jsx
+++ b/src/pages/school-positioning.jsx
@@ -703,10 +703,10 @@ export default function SchoolPositioningPage() {
         <meta property="og:title" content={pageTitle} />
         <meta property="og:description" content={pageDesc} />
         <meta property="og:type" content="website" />
-        {!positioningAvailable && <meta name="robots" content="noindex" />}
+        <meta name="robots" content="noindex" />
       </Head>
       {positioningAvailable ? (
-        <BrowserOnly fallback={<div className={styles.pageWrapper} />}>
+        <BrowserOnly fallback={<div className={styles.pageWrapper}><h1 className={styles.title}>{t.heroTitle}</h1><p>{t.heroLead}</p></div>}>
           {() => <FormBody />}
         </BrowserOnly>
       ) : <OfflineNotice locale={locale} t={t} />}


### PR DESCRIPTION
Enable the positioning form, preview and checkout entry only for the English locale. Chinese and unsupported locales keep the existing offline notice. Both transactional form routes remain noindex and are excluded from the sitemap; the English loading state includes its heading and explanation. Price remains displayed by Stripe at checkout. Validation: 15 positioning and risk-display tests and 25 SEO tests pass. Hold merge until the backend deployment is confirmed.