### PR TITLE
Add School Plan to English navigation

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -115,6 +115,12 @@ const config = {
             label: '申请跟踪',
           },
           {
+            type: 'custom-schoolPlan',
+            position: 'left',
+            label: 'School Plan',
+            to: '/school-positioning',
+          },
+          {
             href: 'https://github.com/csms-apply/csgrad',
             label: 'GitHub',
             position: 'right',

--- a/src/theme/NavbarItem/ComponentTypes.js
+++ b/src/theme/NavbarItem/ComponentTypes.js
@@ -1,0 +1,7 @@
+import ComponentTypes from '@theme-original/NavbarItem/ComponentTypes';
+import SchoolPlanNavbarItem from './SchoolPlanNavbarItem';
+
+export default {
+  ...ComponentTypes,
+  'custom-schoolPlan': SchoolPlanNavbarItem,
+};

--- a/src/theme/NavbarItem/SchoolPlanNavbarItem.js
+++ b/src/theme/NavbarItem/SchoolPlanNavbarItem.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import DefaultNavbarItem from '@theme/NavbarItem/DefaultNavbarItem';
+
+export default function SchoolPlanNavbarItem(props) {
+  const {i18n: {currentLocale}} = useDocusaurusContext();
+  return currentLocale === 'en' ? <DefaultNavbarItem {...props} /> : null;
+}


### PR DESCRIPTION
Adds a School Plan link to the English desktop navigation and mobile menu, pointing to the international school positioning page. The item follows the current locale, so the closed Chinese service is not promoted. Validation: all 33 UX tests passed; full bilingual build and deployment checks run before release.