### PR TITLE
Use the website API for positioning requests

### DIFF
--- a/src/lib/dp/page-regressions.test.mjs
+++ b/src/lib/dp/page-regressions.test.mjs
@@ -103,13 +103,16 @@ for (const locale of ['zh-Hans', 'en']) {
     const harness = pageHarness('school-positioning-result', ['ResultBody'], {
       locale,
       imports: {
-        '@site/src/lib/positioning/api': {WORKER_BASE_URL: 'https://isolated.invalid'},
+        '@site/src/lib/positioning/api': {POSITIONING_API_BASE: ''},
         '@site/src/lib/analytics/events.mjs': {trackSeoEvent() { throw new Error('No analytics expected'); }},
         '@site/src/lib/analytics/purchase.mjs': {},
       },
       globals: {
         window: {location: {search: '?session_id=e2e_synthetic'}},
-        fetch: async () => { throw new TypeError('Failed to fetch'); },
+        fetch: async (url) => {
+          assert.equal(url, '/api/positioning/result?sessionId=e2e_synthetic');
+          throw new TypeError('Failed to fetch');
+        },
       },
     });
     let tree = harness.render('ResultBody');

--- a/src/lib/positioning/api.js
+++ b/src/lib/positioning/api.js
@@ -1,1 +1,4 @@
 export const WORKER_BASE_URL = 'https://csgrad-positioning.capsfly7.workers.dev';
+
+// Positioning runs on the website server; DP and auth retain the Worker gateway.
+export const POSITIONING_API_BASE = '';

--- a/src/pages/school-positioning-result.jsx
+++ b/src/pages/school-positioning-result.jsx
@@ -3,7 +3,7 @@ import Layout from '@theme/Layout';
 import BrowserOnly from '@docusaurus/BrowserOnly';
 import Head from '@docusaurus/Head';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
-import { WORKER_BASE_URL } from '@site/src/lib/positioning/api';
+import { POSITIONING_API_BASE } from '@site/src/lib/positioning/api';
 import {trackSeoEvent} from '@site/src/lib/analytics/events.mjs';
 import {buildPositioningPurchaseParameters} from '@site/src/lib/analytics/purchase.mjs';
 import styles from './school-positioning-result.module.css';
@@ -341,7 +341,7 @@ function ResultBody() {
       count += 1;
       setAttempt(count);
       try {
-        const url = WORKER_BASE_URL + '/api/positioning/result?sessionId=' + encodeURIComponent(sessionId);
+        const url = POSITIONING_API_BASE + '/api/positioning/result?sessionId=' + encodeURIComponent(sessionId);
         const res = await fetch(url);
         if (!res.ok) {
           const text = await res.text().catch(() => '');

--- a/src/pages/school-positioning.jsx
+++ b/src/pages/school-positioning.jsx
@@ -4,7 +4,7 @@ import BrowserOnly from '@docusaurus/BrowserOnly';
 import Head from '@docusaurus/Head';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import { FIELD_DEFINITIONS } from '@site/src/lib/positioning/profile-schema';
-import { WORKER_BASE_URL } from '@site/src/lib/positioning/api';
+import { POSITIONING_API_BASE } from '@site/src/lib/positioning/api';
 import {trackSeoEvent} from '@site/src/lib/analytics/events.mjs';
 import styles from './school-positioning.module.css';
 
@@ -374,7 +374,7 @@ function FormBody() {
     setSubmitting(true);
     setPreview(null);
     try {
-      const res = await fetch(WORKER_BASE_URL + '/api/positioning/preview', {
+      const res = await fetch(POSITIONING_API_BASE + '/api/positioning/preview', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(positioningPayload(profile, fields, locale)),
@@ -407,7 +407,7 @@ function FormBody() {
     setErrorMsg('');
     setPaying(true);
     try {
-      const res = await fetch(WORKER_BASE_URL + '/api/positioning/checkout', {
+      const res = await fetch(POSITIONING_API_BASE + '/api/positioning/checkout', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(positioningPayload(profile, fields, locale)),


### PR DESCRIPTION
Send positioning preview, checkout and result polling to same-origin /api endpoints for the server migration. Keep the existing Worker base URL for DP and authentication, preserving their gateway and callback behavior. Validation: 26 positioning, result-polling and DP regression tests pass, including exact same-origin polling URLs in both languages. Hold merge until the server API is ready.