### PR TITLE
Clarify program cards and fix PDF page alignment

### DIFF
--- a/scripts/positioning-pdf.test.cjs
+++ b/scripts/positioning-pdf.test.cjs
@@ -25,7 +25,7 @@ test('program links localize internal routes and preserve external/already encod
 test('PDF uses an isolated A4 clone and removes it after success or save failure',async()=>{
  for(const fail of [false,true]) {
   let appended,removed=false,options,usedSource,fontReady=false,saveCalls=0,overlayRemoved=false;
-  const classes=[];const clone={classList:{add:value=>classes.push(value)}};
+  const classes=[];const clone={classList:{add:value=>classes.push(value)},querySelectorAll:()=>[]};
   const report={cloneNode:deep=>{assert.equal(deep,true);return clone;}};
   const host={style:{},setAttribute(name,value){assert.equal(name,'aria-hidden');assert.equal(value,'true');},appendChild(node){assert.equal(node,clone);},remove(){removed=true;}};
   const doc={createElement:tag=>{assert.equal(tag,'div');return host;},body:{appendChild:node=>{appended=node;}},fonts:{ready:Promise.resolve().then(()=>{fontReady=true;})}};
@@ -33,7 +33,7 @@ test('PDF uses an isolated A4 clone and removes it after success or save failure
   const result=api.exportReportPdf(report,html2pdf,'report.pdf',doc);
   if(fail)await assert.rejects(result,/simulated save failure/);else await result;
   assert.equal(appended,host);assert.equal(removed,true);assert.equal(overlayRemoved,true);assert.equal(usedSource,clone);assert.notEqual(usedSource,report);
-  assert.deepEqual(classes,['pdfReport']);assert.equal(options.jsPDF.format,'a4');assert.equal(options.html2canvas.windowWidth,794);assert.equal(saveCalls,1);
+  assert.deepEqual(classes,['pdfReport']);assert.equal(options.jsPDF.format,'a4');assert.equal(options.html2canvas.windowWidth,undefined);assert.equal(saveCalls,1);
  }
 });
 
@@ -44,4 +44,24 @@ test('export failure is wired to a localized visible alert and PDF-only layout r
  const css=fs.readFileSync(require('node:path').join(__dirname,'../src/pages/school-positioning-result.module.css'),'utf8');
  assert.match(css,/\.pdfReport \.bucketsGrid,[\s\S]*?display: block !important/);
  assert.match(css,/\.pdfReport \.schoolCard,[\s\S]*?break-inside: avoid/);
+});
+
+test('PDF heading groups retain the first card/list item and every remaining node in order',()=>{
+ class Element {
+  constructor(tag,name='',children=[]){this.tagName=tag.toUpperCase();this.className=name;this.children=[];this.parentNode=null;this.classList={contains:n=>this.className.split(' ').includes(n)};children.forEach(c=>this.appendChild(c));}
+  get firstElementChild(){return this.children[0]||null;}
+  get nextElementSibling(){return this.parentNode?.children[this.parentNode.children.indexOf(this)+1]||null;}
+  matches(){return ['UL','OL'].includes(this.tagName);}
+  appendChild(child){if(child.parentNode)child.parentNode.children.splice(child.parentNode.children.indexOf(child),1);this.children.push(child);child.parentNode=this;}
+  insertBefore(child,before){this.children.splice(this.children.indexOf(before),0,child);child.parentNode=this;}
+ }
+ const heading=new Element('div','bucketHeader'),card1=new Element('div','schoolCard'),card2=new Element('div','schoolCard');
+ const list=new Element('div','schoolList',[card1,card2]),bucket=new Element('div','bucket',[heading,list]);
+ const title=new Element('h2'),item1=new Element('li'),item2=new Element('li'),ul=new Element('ul','',[item1,item2]);
+ const checklist=new Element('section','adviceCard',[title,ul]);
+ api.preparePdfLayout({querySelectorAll:()=>[bucket,checklist]},{createElement:tag=>new Element(tag)});
+ assert.equal(bucket.firstElementChild.className,'pdfKeepTogether');
+ assert.deepEqual(bucket.firstElementChild.children,[heading,card1]);assert.deepEqual(list.children,[card2]);
+ assert.equal(checklist.firstElementChild.className,'pdfKeepTogether');assert.equal(checklist.firstElementChild.children[0],title);
+ assert.equal(checklist.firstElementChild.children[1].tagName,'UL');assert.deepEqual(checklist.firstElementChild.children[1].children,[item1]);assert.deepEqual(ul.children,[item2]);
 });

--- a/scripts/positioning-risk-display.test.cjs
+++ b/scripts/positioning-risk-display.test.cjs
@@ -54,3 +54,22 @@ test('risk and alternatives are part of the same DOM subtree exported to PDF', (
   assert.match(source, /exportReportPdf\(reportRef.current/);
   assert.match(source, /\.from\(clone\)/);
 });
+
+test('program overview replaces generic fit details without changing links or old reports', () => {
+  const item = {bucket:'match',school:'Example MCS',doc:'/A/Example MCS',reason:'Legacy reason',
+    programOverview:{en:'A coursework program with a capstone <project>.','zh-Hans':'以课程和毕业项目为主。'},
+    fit:{trackMatch:'aligned',reasons:[{en:'Generic fit reason','zh-Hans':'通用适配理由'}],checks:[{message:{en:'Generic verify task','zh-Hans':'通用核验任务'}}]}};
+  for (const [locale,expected] of [['en','A coursework program with a capstone &lt;project&gt;.'],['zh-Hans','以课程和毕业项目为主。']]) {
+    const html=render(ReviewedAlternatives,{locale,items:[item]});
+    assert.ok(html.includes(expected));
+    assert.ok(!html.includes('<project>'));
+    assert.doesNotMatch(html,/Generic fit reason|Generic verify task|通用适配理由|通用核验任务|Legacy reason/);
+    assert.ok(html.includes(locale==='en'?'/en/A/Example%20MCS':'/A/Example%20MCS'));
+  }
+  const old=render(ReviewedAlternatives,{locale:'en',items:[{...item,programOverview:undefined}]});
+  assert.match(old,/Generic fit reason/);assert.match(old,/Generic verify task/);
+  const empty=render(ReviewedAlternatives,{locale:'en',items:[{...item,programOverview:{en:'   ','zh-Hans':'仅中文'}}]});
+  assert.match(empty,/Generic fit reason/);assert.doesNotMatch(empty,/仅中文/);
+  const legacy=render(ReviewedAlternatives,{locale:'en',items:[{...item,programOverview:undefined,fit:undefined}]});
+  assert.match(legacy,/Legacy reason/);
+});

--- a/src/pages/school-positioning-result.jsx
+++ b/src/pages/school-positioning-result.jsx
@@ -170,6 +170,31 @@ export function programDetailHref(raw, locale) {
   return encodeURI(path).replace(/%25([0-9a-f]{2})/gi, '%$1');
 }
 
+// html2pdf does not implement break-after:avoid, so group headings with the
+// first content block in the detached copy instead of relying on that CSS rule.
+export function preparePdfLayout(root, doc) {
+  for (const section of root.querySelectorAll(`.${styles.bucket}, .${styles.adviceCard}, .${styles.phdSection}, .${styles.codingSection}`)) {
+    const heading = section.firstElementChild;
+    const content = heading?.nextElementSibling;
+    if (!heading || !content) continue;
+    const list = content.matches('ul, ol') || [styles.schoolList, styles.phdList, styles.codingList, styles.adviceProse].some(name => content.classList.contains(name));
+    const first = list ? content.firstElementChild : content;
+    if (!first) continue;
+    const group = doc.createElement('div');
+    group.className = styles.pdfKeepTogether;
+    section.insertBefore(group, heading);
+    group.appendChild(heading);
+    if (content.matches('ul, ol')) {
+      const firstList = doc.createElement(content.tagName.toLowerCase());
+      firstList.className = content.className;
+      firstList.appendChild(first);
+      group.appendChild(firstList);
+    } else {
+      group.appendChild(first);
+    }
+  }
+}
+
 // Render a separate A4-width copy so PDF layout never changes the visible report.
 export async function exportReportPdf(report, html2pdf, filename, doc = document) {
   const host = doc.createElement('div');
@@ -177,6 +202,7 @@ export async function exportReportPdf(report, html2pdf, filename, doc = document
   host.setAttribute('aria-hidden', 'true');
   const clone = report.cloneNode(true);
   clone.classList.add(styles.pdfReport);
+  preparePdfLayout(clone, doc);
   host.appendChild(clone);
   doc.body.appendChild(host);
   let worker;
@@ -186,7 +212,7 @@ export async function exportReportPdf(report, html2pdf, filename, doc = document
     await worker.set({
       margin: [12, 10, 12, 10], filename,
       image: { type: 'jpeg', quality: 0.95 },
-      html2canvas: { scale: 2, useCORS: true, backgroundColor: '#ffffff', windowWidth: 794 },
+      html2canvas: { scale: 2, useCORS: true, backgroundColor: '#ffffff' },
       jsPDF: { unit: 'mm', format: 'a4', orientation: 'portrait' },
       pagebreak: { mode: ['css', 'legacy'] },
     }).from(clone).save();

--- a/src/pages/school-positioning-result.jsx
+++ b/src/pages/school-positioning-result.jsx
@@ -203,14 +203,18 @@ function SchoolCard({ school, locale, t }) {
   const personalized = getLabel(school.personalizedReason, locale);
   const fallbackReason = getLabel(school.reason, locale);
   const reason = personalized || fallbackReason;
+  const overviewValue = typeof school.programOverview === 'string' ? school.programOverview : school.programOverview?.[locale];
+  const overview = typeof overviewValue === 'string' ? overviewValue.trim() : '';
   const rawHref = school.doc || school.slug || school.url || school.link;
   const href = programDetailHref(rawHref, locale);
   return (
     <div className={styles.schoolCard}>
       <h4 className={styles.schoolName}>{name || '—'}</h4>
       {program && <p className={styles.schoolProgram}>{program}</p>}
-      {!school.fit && reason && <p className={styles.schoolReason}>{reason}</p>}
-      <ProgramFit fit={school.fit} locale={locale} />
+      {overview ? <p className={styles.schoolReason}>{overview}</p> : <>
+        {!school.fit && reason && <p className={styles.schoolReason}>{reason}</p>}
+        <ProgramFit fit={school.fit} locale={locale} />
+      </>}
       {href && (
         <a className={styles.schoolLink} href={href}>
           {t.viewDetail} &rarr;

--- a/src/pages/school-positioning-result.module.css
+++ b/src/pages/school-positioning-result.module.css
@@ -784,6 +784,11 @@
 }
 
 .pdfReport .bucketsGrid,
+.pdfReport .bucket,
+.pdfReport .bucketHeader,
+.pdfReport .schoolList,
+.pdfReport .warningList,
+.pdfReport .reportHeader,
 .pdfReport .phdList,
 .pdfReport .codingList {
   display: block !important;
@@ -803,6 +808,8 @@
 }
 
 .pdfReport .schoolCard,
+.pdfReport .adviceCard,
+.pdfReport .pdfKeepTogether,
 .pdfReport .warningItem,
 .pdfReport p,
 .pdfReport li {
@@ -834,4 +841,16 @@
   border: 1px solid #d6a09b;
   padding: 12px 16px;
   border-radius: 8px;
+}
+
+.pdfReport .tierName {
+  font-size: 2.2rem !important;
+}
+
+.pdfReport .tierHeader {
+  padding: 24px 18px !important;
+}
+
+.pdfReport .bucketHeader {
+  break-inside: avoid;
 }


### PR DESCRIPTION
Report cards with a localized programOverview now display that description instead of generic fit/verification prompts. Reports without an overview retain their previous content and localized links; classification and selection are unchanged.

Also fixes the remaining PDF heading cuts observed after the single-column export change. A screenshot-only viewport override changed responsive layout after html2pdf had calculated page breaks, shifting headings upward by 30 pixels. Export now uses consistent geometry, explicit PDF-only sizing and block flow. Section headings are grouped with their first content block because html2pdf does not implement break-after:avoid.

Validation: all 53 UX tests passed. An isolated Chrome fixture reproduced the old 30.078-pixel shift; after the fix, all 16 measured headings/groups had zero shift and none crossed a page boundary. Tests cover overview compatibility, clone cleanup, heading/card/list grouping and localized links. Production PDF pagination will be rechecked after deployment.
