### PR TITLE
Fix duplicate report headings and legacy UW CSE links

### DIFF
--- a/scripts/positioning-legacy-route.test.cjs
+++ b/scripts/positioning-legacy-route.test.cjs
@@ -1,0 +1,23 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {readFileSync,existsSync} = require('node:fs');
+const {join} = require('node:path');
+const root = join(__dirname,'..');
+const destination = 'https://www.cs.washington.edu/academics/graduate/pmp/';
+const route = 'A/uw pmp cse/index.html';
+function verify(file) {
+ const html = readFileSync(file,'utf8');
+ assert.ok(html.includes(`content="0;url=${destination}"`));
+ assert.ok(html.includes(`href="${destination}"`));
+ assert.match(html,/<meta name="robots" content="noindex">/);
+ assert.doesNotMatch(html,/uw ee pmp/);
+}
+test('frozen UW CSE PMP links lead to the correct official program without JavaScript',()=>{
+ verify(join(root,'static',route));
+});
+// CI builds both locales before test:ux, verifying Docusaurus copied the static
+// fallback to each locale output (the source is shared, not two diverging pages).
+test('both deployed locale paths retain the legacy redirect', {skip:!existsSync(join(root,'build'))},()=>{
+ verify(join(root,'build',route));
+ verify(join(root,'build/en',route));
+});

--- a/scripts/positioning-risk-display.test.cjs
+++ b/scripts/positioning-risk-display.test.cjs
@@ -23,7 +23,7 @@ vm.runInNewContext(code, {
     throw new Error(`Unexpected import: ${name}`);
   },
 });
-const { RiskNotice, ReviewedAlternatives } = exportsForTest;
+const { RiskNotice, ReviewedAlternatives, Bucket } = exportsForTest;
 const render = (component, props) => renderToStaticMarkup(React.createElement(component, props));
 
 test('uncalibrated policy text is visible and escaped', () => {
@@ -72,4 +72,19 @@ test('program overview replaces generic fit details without changing links or ol
   assert.match(empty,/Generic fit reason/);assert.doesNotMatch(empty,/仅中文/);
   const legacy=render(ReviewedAlternatives,{locale:'en',items:[{...item,programOverview:undefined,fit:undefined}]});
   assert.match(legacy,/Legacy reason/);
+});
+
+test('bucket headers do not repeat identical labels and retain distinct Chinese subtitles', () => {
+  for (const title of ['Reach','Match','Alternatives']) {
+    const html=render(Bucket,{items:[],title,subtitle:title,locale:'en',t:{emptyBucket:'No programs'}});
+    const heading=html.match(/<h3[^>]*>(.*?)<\/h3>/)[1];
+    assert.equal(heading,title);
+  }
+  for (const [title,subtitle] of [['冲刺','Reach'],['主申','Match'],['备选','Alternatives']]) {
+    const html=render(Bucket,{items:[],title,subtitle,locale:'zh-Hans',t:{emptyBucket:'暂无项目'}});
+    const heading=html.match(/<h3[^>]*>(.*?)<\/h3>/)[1];
+    assert.ok(heading.startsWith(title));
+    assert.equal(heading.split(title).length-1,1);
+    assert.ok(heading.includes(subtitle));
+  }
 });

--- a/src/pages/school-positioning-result.jsx
+++ b/src/pages/school-positioning-result.jsx
@@ -301,14 +301,14 @@ function AdviceSection({ advice, t }) {
   );
 }
 
-function Bucket({ items, title, subtitle, variantClass, locale, t }) {
+export function Bucket({ items, title, subtitle, variantClass, locale, t }) {
   const list = Array.isArray(items) ? items : [];
   return (
     <div className={`${styles.bucket} ${variantClass}`}>
       <div className={styles.bucketHeader}>
         <h3 className={styles.bucketTitle}>
           {title}
-          <span className={styles.bucketSubtitle}>{subtitle}</span>
+          {subtitle && subtitle !== title && <span className={styles.bucketSubtitle}>{subtitle}</span>}
         </h3>
         <span className={styles.bucketCount}>{list.length}</span>
       </div>

--- a/static/A/uw pmp cse/index.html
+++ b/static/A/uw pmp cse/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex">
+  <meta http-equiv="refresh" content="0;url=https://www.cs.washington.edu/academics/graduate/pmp/">
+  <link rel="canonical" href="https://www.cs.washington.edu/academics/graduate/pmp/">
+  <title>UW Computer Science Professional Master's Program</title>
+</head>
+<body>
+  <p><a href="https://www.cs.washington.edu/academics/graduate/pmp/">Open the official UW Computer Science Professional Master's Program page / 前往华盛顿大学计算机 PMP 项目官网</a></p>
+</body>
+</html>


### PR DESCRIPTION
English report buckets rendered the same text as both title and subtitle, producing repeated Reach, Match and Alternatives headings. Identical subtitles are now omitted; distinct Chinese/English bilingual labels remain unchanged.

Also restores frozen report links to the removed UW CSE PMP document. A noindex static redirect sends the legacy default-language and English paths to the verified official CSE PMP page, with a usable link when automatic refresh is unavailable. It does not point to the distinct UW EE program.

Validation: 55 local UX tests passed; the built-locale redirect test runs after the CI build (skipped locally without build output). The official destination returned HTTP 200. CI verifies that both locale outputs contain the redirect. Other report layout and selection behavior are unchanged.
