### PR TITLE
Keep paid reports available during deployment and fix PDF contrast

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,6 +47,9 @@ jobs:
             exit 1
           fi
 
+      - name: Test atomic deployment activation
+        run: python3 scripts/atomic-deploy.test.py
+
       - name: Test SEO safeguards
         run: npm run test:seo
 

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ scripts/migration-output/
 # Atomic deployment releases
 .site-releases/
 .build-link-*
+
+.site-deploy.lock

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ src/theme/Layout/
 # free-text fields stripped.
 DataPoints.dtable
 scripts/migration-output/
+
+# Atomic deployment releases
+.site-releases/
+.build-link-*

--- a/run.sh
+++ b/run.sh
@@ -23,5 +23,10 @@ if ! command -v pm2 >/dev/null 2>&1; then
 fi
 # The server resolves build paths per request; switching the symlink is enough.
 # Restarting here would create an unnecessary gap in report availability.
-pm2 describe docusaurus >/dev/null 2>&1 || pm2 start npm --name "docusaurus" -- run serve
+csgrad_pm2_status="$(pm2 jlist | node -e 'let s=""; process.stdin.on("data",c=>s+=c); process.stdin.on("end",()=>{ const p=JSON.parse(s).find(p=>p.name==="docusaurus"); console.log(p?.pm2_env?.status || "missing"); });')"
+if [ "$csgrad_pm2_status" = missing ]; then
+  pm2 start npm --name "docusaurus" -- run serve
+elif [ "$csgrad_pm2_status" != online ]; then
+  pm2 restart docusaurus
+fi
 pm2 save

--- a/run.sh
+++ b/run.sh
@@ -9,6 +9,10 @@ fi
 
 set -euo pipefail
 
+# Serialize builds, activation and cleanup across overlapping SSH deployments.
+exec 9>.site-deploy.lock
+flock 9
+
 npm ci
 # Build away from the directory currently served by Docusaurus.
 mkdir -p .site-releases

--- a/run.sh
+++ b/run.sh
@@ -10,9 +10,18 @@ fi
 set -euo pipefail
 
 npm ci
-npm run build
+# Build away from the directory currently served by Docusaurus.
+mkdir -p .site-releases
+csgrad_release="$(mktemp -d "$PWD/.site-releases/release-XXXXXXXX")"
+if ! npm run build -- --out-dir "$csgrad_release"; then
+  rm -rf "$csgrad_release"
+  exit 1
+fi
+python3 scripts/activate-build.py "$PWD" "$csgrad_release"
 if ! command -v pm2 >/dev/null 2>&1; then
   sudo npm install -g pm2
 fi
-pm2 restart docusaurus || pm2 start npm --name "docusaurus" -- run serve
+# The server resolves build paths per request; switching the symlink is enough.
+# Restarting here would create an unnecessary gap in report availability.
+pm2 describe docusaurus >/dev/null 2>&1 || pm2 start npm --name "docusaurus" -- run serve
 pm2 save

--- a/scripts/activate-build.py
+++ b/scripts/activate-build.py
@@ -4,6 +4,7 @@ import ctypes
 import os
 import json
 import shutil
+import re
 from pathlib import Path
 import sys
 import uuid
@@ -20,6 +21,7 @@ def activate(site, release):
     live = site / 'build'
     # Keep precisely the previous build's own assets for already open tabs.
     # Record fresh assets before copying so retention does not grow recursively.
+    previous_release = live.resolve() if live.exists() else None
     manifest = '.original-assets.json'
     fresh = [str(p.relative_to(release)) for p in release.rglob('*')
              if p.is_file() and 'assets' in p.relative_to(release).parts]
@@ -52,12 +54,19 @@ def activate(site, release):
             renameat2.restype = ctypes.c_int
             if renameat2(-100, os.fsencode(staging), -100, os.fsencode(live), 2):
                 raise OSError(ctypes.get_errno(), 'Atomic build exchange failed')
-            staging.rename(site / '.site-releases' / ('legacy-' + uuid.uuid4().hex))
+            previous_release = site / '.site-releases' / ('legacy-' + uuid.uuid4().hex)
+            staging.rename(previous_release)
         else:
             os.replace(staging, live)
     finally:
         if staging.is_symlink():
             staging.unlink()
+    # Only remove releases created by this deployer, keeping one rollback build.
+    for candidate in (site / '.site-releases').iterdir():
+        if (re.fullmatch(r'(release-[A-Za-z0-9]{8}|legacy-[a-f0-9]{32})', candidate.name)
+                and candidate.is_dir() and not candidate.is_symlink()
+                and candidate.resolve() not in (release, previous_release)):
+            shutil.rmtree(candidate)
 
 
 if __name__ == '__main__':

--- a/scripts/activate-build.py
+++ b/scripts/activate-build.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Publish a complete build without removing the currently served directory."""
+import ctypes
+import os
+import json
+import shutil
+from pathlib import Path
+import sys
+import uuid
+
+
+def activate(site, release):
+    site = Path(site).resolve()
+    release = Path(release).resolve()
+    if release.parent != site / '.site-releases':
+        raise ValueError('Release must be directly inside .site-releases')
+    for page in ('index.html', 'en/index.html', 'school-positioning-result/index.html', 'en/school-positioning-result/index.html'):
+        if not (release / page).is_file():
+            raise ValueError(f'Incomplete release: missing {page}')
+    live = site / 'build'
+    # Keep precisely the previous build's own assets for already open tabs.
+    # Record fresh assets before copying so retention does not grow recursively.
+    manifest = '.original-assets.json'
+    fresh = [str(p.relative_to(release)) for p in release.rglob('*')
+             if p.is_file() and 'assets' in p.relative_to(release).parts]
+    if live.is_dir():
+        if (live / manifest).is_file():
+            previous = json.loads((live / manifest).read_text())
+        else:
+            previous = [str(p.relative_to(live)) for p in live.rglob('*')
+                        if p.is_file() and 'assets' in p.relative_to(live).parts]
+        for name in previous:
+            relative = Path(name)
+            if relative.is_absolute() or '..' in relative.parts or 'assets' not in relative.parts:
+                raise ValueError('Invalid previous asset manifest')
+            source, target = live / relative, release / relative
+            if source.is_file() and not target.exists():
+                target.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(source, target)
+    (release / manifest).write_text(json.dumps(fresh))
+    staging = site / ('.build-link-' + uuid.uuid4().hex)
+    staging.symlink_to(os.path.relpath(release, site), target_is_directory=True)
+    try:
+        if live.is_dir() and not live.is_symlink():
+            # Linux atomically exchanges a legacy directory and the new symlink.
+            # Unsupported platforms fail with the old directory untouched.
+            libc = ctypes.CDLL(None, use_errno=True)
+            renameat2 = getattr(libc, 'renameat2', None)
+            if renameat2 is None:
+                raise RuntimeError('Initial activation requires Linux renameat2')
+            renameat2.argtypes = [ctypes.c_int, ctypes.c_char_p, ctypes.c_int, ctypes.c_char_p, ctypes.c_uint]
+            renameat2.restype = ctypes.c_int
+            if renameat2(-100, os.fsencode(staging), -100, os.fsencode(live), 2):
+                raise OSError(ctypes.get_errno(), 'Atomic build exchange failed')
+            staging.rename(site / '.site-releases' / ('legacy-' + uuid.uuid4().hex))
+        else:
+            os.replace(staging, live)
+    finally:
+        if staging.is_symlink():
+            staging.unlink()
+
+
+if __name__ == '__main__':
+    activate(sys.argv[1], sys.argv[2])

--- a/scripts/atomic-deploy.test.py
+++ b/scripts/atomic-deploy.test.py
@@ -1,0 +1,68 @@
+import importlib.util
+from pathlib import Path
+import tempfile
+import unittest
+import sys
+
+spec = importlib.util.spec_from_file_location('activate', Path(__file__).with_name('activate-build.py'))
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+class ActivationTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.site = Path(self.temp.name)
+        self.releases = self.site / '.site-releases'
+        self.releases.mkdir()
+
+    def release(self, name):
+        root = self.releases / name
+        for page in ('index.html', 'en/index.html', 'school-positioning-result/index.html', 'en/school-positioning-result/index.html'):
+            path = root / page
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(name)
+        return root
+
+    def test_complete_release_switches_existing_server_path(self):
+        old, new = self.release('old'), self.release('new')
+        live = self.site / 'build'
+        live.symlink_to(old)
+        module.activate(self.site, new)
+        self.assertEqual((live / 'en/school-positioning-result/index.html').read_text(), 'new')
+        self.assertEqual((old / 'index.html').read_text(), 'old')
+
+    def test_previous_assets_survive_but_do_not_accumulate(self):
+        versions = [self.release(name) for name in ('old', 'new', 'third')]
+        for version in versions:
+            (version / 'assets/js').mkdir(parents=True)
+            (version / 'assets/js' / (version.name + '.js')).write_text(version.name)
+        (self.site / 'build').symlink_to(versions[0])
+        module.activate(self.site, versions[1])
+        self.assertEqual((self.site / 'build/assets/js/old.js').read_text(), 'old')
+        module.activate(self.site, versions[2])
+        self.assertEqual((self.site / 'build/assets/js/new.js').read_text(), 'new')
+        self.assertFalse((self.site / 'build/assets/js/old.js').exists())
+
+    def test_incomplete_release_preserves_live(self):
+        old, new = self.release('old'), self.release('new')
+        (self.site / 'build').symlink_to(old)
+        (new / 'en/index.html').unlink()
+        with self.assertRaises(ValueError):
+            module.activate(self.site, new)
+        self.assertEqual((self.site / 'build/index.html').read_text(), 'old')
+
+    def test_legacy_directory_exchange_or_safe_platform_failure(self):
+        old, new = self.release('old'), self.release('new')
+        old.rename(self.site / 'build')
+        if sys.platform == 'linux':
+            module.activate(self.site, new)
+            self.assertTrue((self.site / 'build').is_symlink())
+            self.assertEqual((self.site / 'build/index.html').read_text(), 'new')
+        else:
+            with self.assertRaises(RuntimeError):
+                module.activate(self.site, new)
+            self.assertEqual((self.site / 'build/index.html').read_text(), 'old')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/atomic-deploy.test.py
+++ b/scripts/atomic-deploy.test.py
@@ -44,6 +44,18 @@ class ActivationTests(unittest.TestCase):
         self.assertEqual((self.site / 'build/assets/js/new.js').read_text(), 'new')
         self.assertFalse((self.site / 'build/assets/js/old.js').exists())
 
+    def test_cleanup_keeps_current_previous_and_unowned_directories(self):
+        stale = self.release('release-00000000')
+        old = self.release('release-11111111')
+        new = self.release('release-22222222')
+        unowned = self.release('operator-backup')
+        (self.site / 'build').symlink_to(old)
+        module.activate(self.site, new)
+        self.assertFalse(stale.exists())
+        self.assertTrue(old.exists())
+        self.assertTrue(new.exists())
+        self.assertTrue(unowned.exists())
+
     def test_incomplete_release_preserves_live(self):
         old, new = self.release('old'), self.release('new')
         (self.site / 'build').symlink_to(old)

--- a/scripts/positioning-deploy.test.cjs
+++ b/scripts/positioning-deploy.test.cjs
@@ -1,0 +1,38 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const http = require('node:http');
+const {execFileSync} = require('node:child_process');
+const handler = require('serve-handler');
+
+test('running static server follows activation and serves previous PDF chunk URL', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'csgrad-activation-'));
+  const releases = path.join(root, '.site-releases');
+  for (const version of ['old', 'new']) {
+    for (const file of ['index.html', 'en/index.html', 'school-positioning-result/index.html', 'en/school-positioning-result/index.html', `assets/js/pdf-${version}.js`]) {
+      const output = path.join(releases, version, file);
+      fs.mkdirSync(path.dirname(output), {recursive:true});
+      fs.writeFileSync(output, version);
+    }
+  }
+  fs.symlinkSync(path.join(releases,'old'), path.join(root,'build'));
+  const server = http.createServer((req,res) => handler(req,res,{public:path.join(root,'build')}));
+  try {
+    await new Promise(resolve => server.listen(0,'127.0.0.1',resolve));
+    const origin = `http://127.0.0.1:${server.address().port}`;
+    assert.equal(await (await fetch(origin)).text(), 'old');
+    const oldChunk = `${origin}/assets/js/pdf-old.js`;
+    assert.equal((await fetch(oldChunk)).status, 200);
+    execFileSync('python3', [path.join(__dirname,'activate-build.py'),root,path.join(releases,'new')]);
+    assert.equal(await (await fetch(origin)).text(), 'new');
+    const oldResponse = await fetch(oldChunk);
+    assert.equal(oldResponse.status,200);
+    assert.equal(await oldResponse.text(),'old');
+    assert.equal(await (await fetch(`${origin}/assets/js/pdf-new.js`)).text(),'new');
+  } finally {
+    await new Promise(resolve => server.close(resolve));
+    fs.rmSync(root,{recursive:true,force:true});
+  }
+});

--- a/scripts/positioning-pdf.test.cjs
+++ b/scripts/positioning-pdf.test.cjs
@@ -65,3 +65,8 @@ test('PDF heading groups retain the first card/list item and every remaining nod
  assert.equal(checklist.firstElementChild.className,'pdfKeepTogether');assert.equal(checklist.firstElementChild.children[0],title);
  assert.equal(checklist.firstElementChild.children[1].tagName,'UL');assert.deepEqual(checklist.firstElementChild.children[1].children,[item1]);assert.deepEqual(ul.children,[item2]);
 });
+
+test('PDF count badges and contact control have an explicit light color pair',()=>{
+ const css=fs.readFileSync(require('node:path').join(__dirname,'../src/pages/school-positioning-result.module.css'),'utf8');
+ assert.match(css,/\.pdfReport \.bucketCount,\s*\.pdfReport \.consultHandle\s*\{[^}]*background: #f2f2f2 !important;[^}]*color: #242424 !important;/);
+});

--- a/src/pages/school-positioning-result.module.css
+++ b/src/pages/school-positioning-result.module.css
@@ -854,3 +854,11 @@
 .pdfReport .bucketHeader {
   break-inside: avoid;
 }
+
+/* Keep small controls readable even when the source page uses dark mode. */
+.pdfReport .bucketCount,
+.pdfReport .consultHandle {
+  background: #f2f2f2 !important;
+  color: #242424 !important;
+  border-color: #cccccc !important;
+}


### PR DESCRIPTION
Paid report pages could return 404 during deployment because the production build directory was cleared while still being served. Build into an isolated release, validate the main English/Chinese pages, then atomically replace the build link. The initial Linux directory-to-link transition uses renameat2 exchange and fails without removing the old site if unavailable. The existing HTTP process stays running.

Keep the previous build's original assets in the new release so already-open reports can load their previous PDF chunk. A manifest prevents copied assets accumulating across generations. Retain only the current and previous deployer-owned release for rollback; unrelated directories are never pruned. Recover stopped/errored PM2 processes while leaving an online process running.

Also give exported PDF count badges and the WeChat control an explicit light background/dark text pair, fixing illegibility when exporting from dark mode.

Validation: five activation tests (Linux exchange exercised in CI), a real serve-handler HTTP test verifies content changes without restarting and the previous PDF asset URL remains HTTP 200, and PDF/UX regression tests. No real payment or email calls.
