### PR TITLE
统一首页标题为「北美 MSCS 申请指南」

### DIFF
--- a/docs/intro.mdx
+++ b/docs/intro.mdx
@@ -1,6 +1,6 @@
 ---
 id: intro
-title: 北美MSCS申请
+title: 北美 MSCS 申请指南
 slug: /
 description: CS Grad 提供北美 CS、MSCS 及相关硕士项目介绍、申请数据和选校参考，帮助申请者结合课程、成本与就业方向评估项目。
 hide_title: true
@@ -8,7 +8,7 @@ hide_title: true
 
 import VisitorGeoMap from '@site/src/components/VisitorGeoMap';
 
-# CS Grad：北美 MSCS 申请与选校指南
+# 北美 MSCS 申请指南
 
 ![License: CC BY-NC-SA 4.0](https://img.shields.io/badge/License-CC%20BY--NC--SA%204.0-lightgrey.svg)
 [![GitHub Repo stars](https://img.shields.io/github/stars/csms-apply/csgrad)](https://github.com/csms-apply/csgrad)

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -11,7 +11,7 @@ import {themes as prismThemes} from 'prism-react-renderer';
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'CS Grad',
-  tagline: '北美 CS/MSCS 申请与选校指南',
+  tagline: '北美 MSCS 申请指南',
   favicon: 'img/favicon.ico',
 
   // Set the production url of your site here

--- a/i18n/en/docusaurus-plugin-content-docs/current/intro.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/intro.mdx
@@ -1,6 +1,6 @@
 ---
 id: intro
-title: North American CS & MSCS Program Guide
+title: North American MSCS Application Guide
 slug: /
 description: Compare North American CS, MSCS, and related master's programs using practical details on curriculum, cost, flexibility, admissions patterns, and career outcomes.
 hide_title: true
@@ -8,9 +8,9 @@ hide_title: true
 
 import VisitorGeoMap from '@site/src/components/VisitorGeoMap';
 
-# CS Grad: North American CS & MSCS Program Guide
+# North American MSCS Application Guide
 
-<p><a href="https://csgrad.com/" hrefLang="zh-Hans" lang="zh-Hans">查看 CS Grad 中文首页：北美 CS/MSCS 申请与选校指南</a></p>
+<p><a href="https://csgrad.com/" hrefLang="zh-Hans" lang="zh-Hans">查看中文首页：北美 MSCS 申请指南</a></p>
 
 ![License: CC BY-NC-SA 4.0](https://img.shields.io/badge/License-CC%20BY--NC--SA%204.0-lightgrey.svg)
 [![GitHub Repo stars](https://img.shields.io/github/stars/csms-apply/csgrad)](https://github.com/csms-apply/csgrad)


### PR DESCRIPTION
首页主标题统一为「北美 MSCS 申请指南」，去掉原有的「CS Grad：」前缀和「与选校」措辞。同步更新首页页面标题、站点 tagline，以及英文标题 North American MSCS Application Guide。

验证：差异格式检查通过；由 CI 验证中英文构建与现有检查。

本 PR 留待审阅，不自动合并或部署。
