### PR TITLE
README 添加中英文切换及 Discord、QQ 群按钮

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,0 +1,60 @@
+# North American MSCS Application Guide
+
+[简体中文](README.md) | **English**
+
+## Welcome to CS Grad
+
+CS Grad focuses on applications to North American Master of Science in Computer Science (MSCS) programs, with introductions to related fields including computer science (CS), data science (DS), electrical engineering (EE), electrical and computer engineering (ECE), and information systems (IS). The goal is to help applicants with undergraduate degrees from **mainland China** or **North America** understand what each program offers and assess its **practical value** more efficiently. While Open CS App ranks programs primarily by their admission bar—how difficult they are to get into—CS Grad focuses on **what students gain from a program**, especially its support for finding **software development engineer (SDE) jobs in North America**, rather than admission difficulty alone.
+
+To give applicants a fuller picture, we include **admission data points (admission DP)** and **job outcome data points (job DP)**: individual examples that illustrate admissions trends and graduates’ experiences in the job market. After all, most people pursuing an MSCS in the United States ultimately want to find a job, so employment outcomes deserve a place in application decisions.
+
+## Website
+
+[CS Grad English Homepage](https://csgrad.com/en/) | [Chinese Homepage](https://csgrad.com/)
+
+## Join Our QQ Discussion Group
+
+QQ group number: 1039432843
+
+![QQ group](static/img/csgradqqchat.png)
+
+## Why Apply to North American MSCS Programs?
+
+The main reason is to find a job in the United States. The US has the world’s largest tech job market, with companies such as Google, Meta, Apple, Amazon, Netflix, Microsoft, and Nvidia, as well as hedge funds and quantitative trading firms such as Two Sigma, Citadel Securities, D. E. Shaw, and Millennium. Starting pay for new graduates (NG) in tech is around US$200,000; software engineering (SWE) roles at hedge funds start at US$350,000+, and some quantitative research (QR) roles can reach US$500,000+.
+
+The US job market also offers better work–life balance (WLB). Some companies, such as Meta, can be demanding, but compared with ByteDance’s Dazhongsi office in Beijing—still brightly lit at 10 p.m.—the intensity is on a different scale. A common path to working in the US is therefore to pursue an MSCS, complete a summer internship, and try to convert it into a full-time offer, or apply for new-graduate roles afterward.
+
+## How CS Grad Differs from Open CS
+
+As noted above, Open CS ranks programs primarily by their **admission bar**, particularly for **applicants with mainland Chinese undergraduate degrees**. That does not necessarily reflect a program’s **practical value**. Some programs are more welcoming to applicants with **US undergraduate degrees** than to those with **mainland Chinese degrees**, such as Northwestern MSCS and UIUC MCS. Others have a more accessible admission bar but offer very good opportunities afterward, such as UW EE PMP. CS Grad focuses on **what a program offers in practice**, helping applicants make more informed school-selection decisions.
+
+That is why I created CS Grad: to provide a more practical reference for applications and choosing programs.
+
+## How We Determine Program Tiers
+
+The program tiers were developed through discussions among the project’s early core contributors. The main factors include:
+
+- Overall university and subject rankings.
+- Program-specific employment outcomes. Some employment data and individual examples are already included in the program articles.
+- Opportunities to pursue or transition into a PhD, such as Brown ScM CS for students interested in doctoral study.
+- Quality of life, such as the excellent living experience at UCSD.
+- Financial considerations, such as the affordability of Georgia Tech MSCS.
+- Location, such as Columbia and NYU’s locations in New York City.
+- Flexibility in graduation timing, such as UT ECE.
+- Technical depth and rigor of the curriculum, such as the demanding, systems-focused courses in CMU MCDS and MSIN.
+- Access to teaching assistant (TA) and research assistant (RA) positions for master’s students.
+
+**Again, these tiers reflect discussions between me and several early core contributors, so some bias is inevitable. Pull requests suggesting corrections are welcome.**
+
+## North American MSCS Application Timeline
+
+If you are applying to MSCS programs for **Fall 2026** entry, the approximate timeline is:
+
+![MSCS application timeline](static/img/applytimeline.png)
+
+## A Few Principles for Choosing CS Programs
+
+1. You are the sum of your past experiences. No program can completely change your life; lasting change comes from your own willingness to keep growing and exploring.
+2. The more important a life decision is, the less you need to follow someone else’s directions or overanalyze it. Listen patiently to your own intuition. Let instinct guide the broad direction, and use reason to work out the details.
+3. A higher admission bar does not necessarily make a program a better fit for you.
+4. Graduate school is a means of pursuing your aspirations, not a refuge. Life will not stand still on the day you receive an admission offer.

--- a/README.en.md
+++ b/README.en.md
@@ -1,6 +1,11 @@
 <h1 align="center">North American MSCS Application Guide</h1>
 
 <p align="center">
+  <a href="https://discord.gg/g9x4WCX2xz"><img src="static/img/readme/community-discord.svg" alt="Join Discord" width="144" height="44" /></a>
+  <a href="#qq-group"><img src="static/img/readme/community-qq-en.svg" alt="Join QQ group" width="144" height="44" /></a>
+</p>
+
+<p align="center">
   <a href="README.md"><img src="static/img/readme/language-zh-inactive.svg" alt="简体中文" width="144" height="44" /></a>
   <a href="README.en.md"><img src="static/img/readme/language-en-active.svg" alt="English" width="144" height="44" /></a>
 </p>
@@ -14,6 +19,12 @@ To give applicants a fuller picture, we include **admission data points (admissi
 ## Website
 
 [CS Grad English Homepage](https://csgrad.com/en/) | [Chinese Homepage](https://csgrad.com/)
+
+## Join Discord
+
+[Join the CS Grad Discord community](https://discord.gg/g9x4WCX2xz)
+
+<a id="qq-group"></a>
 
 ## Join Our QQ Discussion Group
 

--- a/README.en.md
+++ b/README.en.md
@@ -1,6 +1,9 @@
-# North American MSCS Application Guide
+<h1 align="center">North American MSCS Application Guide</h1>
 
-[简体中文](README.md) | **English**
+<p align="center">
+  <a href="README.md"><img src="static/img/readme/language-zh-inactive.svg" alt="简体中文" width="144" height="44" /></a>
+  <a href="README.en.md"><img src="static/img/readme/language-en-active.svg" alt="English" width="144" height="44" /></a>
+</p>
 
 ## Welcome to CS Grad
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# CS Grad：北美 CS/MSCS 申请与选校指南
+# 北美 MSCS 申请指南
+
+**简体中文** | [English](README.en.md)
 
 ## 欢迎来到 CS Grad 项目
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
-# 北美 MSCS 申请指南
+<h1 align="center">北美 MSCS 申请指南</h1>
 
-**简体中文** | [English](README.en.md)
+<p align="center">
+  <a href="README.md"><img src="static/img/readme/language-zh-active.svg" alt="简体中文" width="144" height="44" /></a>
+  <a href="README.en.md"><img src="static/img/readme/language-en-inactive.svg" alt="English" width="144" height="44" /></a>
+</p>
 
 ## 欢迎来到 CS Grad 项目
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 <h1 align="center">北美 MSCS 申请指南</h1>
 
 <p align="center">
+  <a href="https://discord.gg/g9x4WCX2xz"><img src="static/img/readme/community-discord.svg" alt="Join Discord" width="144" height="44" /></a>
+  <a href="#qq-group"><img src="static/img/readme/community-qq-zh.svg" alt="加入 QQ 群" width="144" height="44" /></a>
+</p>
+
+<p align="center">
   <a href="README.md"><img src="static/img/readme/language-zh-active.svg" alt="简体中文" width="144" height="44" /></a>
   <a href="README.en.md"><img src="static/img/readme/language-en-inactive.svg" alt="English" width="144" height="44" /></a>
 </p>
@@ -13,6 +18,12 @@ CS Grad 项目专注于北美 MSCS 申请，涵盖 CS、DS、EE、ECE、IS 等�
 
 ## 项目网址
 [CS Grad 中文首页](https://csgrad.com/)
+
+## 加入 Discord
+
+[加入 CS Grad Discord 社区](https://discord.gg/g9x4WCX2xz)
+
+<a id="qq-group"></a>
 
 ## 加入QQ群讨论
 qq群号：1039432843

--- a/static/img/readme/community-discord.svg
+++ b/static/img/readme/community-discord.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="144" height="44" viewBox="0 0 144 44" role="img" aria-label="DISCORD">
+  <title>DISCORD</title>
+  <rect width="144" height="44" fill="#5865f2"/>
+  <text x="72" y="23" text-anchor="middle" dominant-baseline="middle" fill="#ffffff" font-family="Arial, Helvetica, Microsoft YaHei, sans-serif" font-size="16" font-weight="700" letter-spacing="2">DISCORD</text>
+</svg>

--- a/static/img/readme/community-qq-en.svg
+++ b/static/img/readme/community-qq-en.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="144" height="44" viewBox="0 0 144 44" role="img" aria-label="QQ GROUP">
+  <title>QQ GROUP</title>
+  <rect width="144" height="44" fill="#1686d9"/>
+  <text x="72" y="23" text-anchor="middle" dominant-baseline="middle" fill="#ffffff" font-family="Arial, Helvetica, Microsoft YaHei, sans-serif" font-size="16" font-weight="700" letter-spacing="2">QQ GROUP</text>
+</svg>

--- a/static/img/readme/community-qq-zh.svg
+++ b/static/img/readme/community-qq-zh.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="144" height="44" viewBox="0 0 144 44" role="img" aria-label="QQ 群">
+  <title>QQ 群</title>
+  <rect width="144" height="44" fill="#1686d9"/>
+  <text x="72" y="23" text-anchor="middle" dominant-baseline="middle" fill="#ffffff" font-family="Arial, Helvetica, Microsoft YaHei, sans-serif" font-size="16" font-weight="700" letter-spacing="2">QQ 群</text>
+</svg>

--- a/static/img/readme/language-en-active.svg
+++ b/static/img/readme/language-en-active.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="144" height="44" viewBox="0 0 144 44" role="img" aria-label="ENGLISH">
+  <title>ENGLISH</title>
+  <rect width="144" height="44" fill="#454545"/>
+  <text x="72" y="23" text-anchor="middle" dominant-baseline="middle" fill="#ffffff" font-family="Arial, Helvetica, Microsoft YaHei, sans-serif" font-size="16" font-weight="700" letter-spacing="2">ENGLISH</text>
+</svg>

--- a/static/img/readme/language-en-inactive.svg
+++ b/static/img/readme/language-en-inactive.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="144" height="44" viewBox="0 0 144 44" role="img" aria-label="ENGLISH">
+  <title>ENGLISH</title>
+  <rect width="144" height="44" fill="#dedede"/>
+  <text x="72" y="23" text-anchor="middle" dominant-baseline="middle" fill="#252525" font-family="Arial, Helvetica, Microsoft YaHei, sans-serif" font-size="16" font-weight="700" letter-spacing="2">ENGLISH</text>
+</svg>

--- a/static/img/readme/language-zh-active.svg
+++ b/static/img/readme/language-zh-active.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="144" height="44" viewBox="0 0 144 44" role="img" aria-label="简体中文">
+  <title>简体中文</title>
+  <rect width="144" height="44" fill="#454545"/>
+  <text x="72" y="23" text-anchor="middle" dominant-baseline="middle" fill="#ffffff" font-family="Arial, Helvetica, Microsoft YaHei, sans-serif" font-size="16" font-weight="700" letter-spacing="2">简体中文</text>
+</svg>

--- a/static/img/readme/language-zh-inactive.svg
+++ b/static/img/readme/language-zh-inactive.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="144" height="44" viewBox="0 0 144 44" role="img" aria-label="简体中文">
+  <title>简体中文</title>
+  <rect width="144" height="44" fill="#dedede"/>
+  <text x="72" y="23" text-anchor="middle" dominant-baseline="middle" fill="#252525" font-family="Arial, Helvetica, Microsoft YaHei, sans-serif" font-size="16" font-weight="700" letter-spacing="2">简体中文</text>
+</svg>


### PR DESCRIPTION
仓库 README 顶部采用居中的矩形按钮：Discord、QQ 群，以及「简体中文 / English」语言切换。当前语言使用深色，另一语言使用浅色；默认保留中文，并新增完整英文 README。

Discord 按钮使用现有社区邀请链接；QQ 群按钮定位到群号与二维码。两份 README 使用相对链接互相切换，英文版提供英文站入口。按钮 SVG 随仓库存储。

中文标题同步为「北美 MSCS 申请指南」。英文版保留原文的章节、例子、数字、QQ 群和两张图片。

验证：Markdown 差异检查、本地链接与图片路径检查通过；在 GitHub 实际渲染页面检查了按钮样式、QQ 定位和英文切换。原有两张正文图片保持不变。
