### PR TITLE
更新首页标题，记住默认语言并增加用户语言统计

### DIFF
--- a/docs/intro.mdx
+++ b/docs/intro.mdx
@@ -1,6 +1,6 @@
 ---
 id: intro
-title: 北美 MSCS 申请指南
+title: 'CS Grad: 北美MSCS 申请指南'
 slug: /
 description: CS Grad 提供北美 CS、MSCS 及相关硕士项目介绍、申请数据和选校参考，帮助申请者结合课程、成本与就业方向评估项目。
 hide_title: true
@@ -8,7 +8,7 @@ hide_title: true
 
 import VisitorGeoMap from '@site/src/components/VisitorGeoMap';
 
-# 北美 MSCS 申请指南
+# CS Grad: 北美MSCS 申请指南
 
 ![License: CC BY-NC-SA 4.0](https://img.shields.io/badge/License-CC%20BY--NC--SA%204.0-lightgrey.svg)
 [![GitHub Repo stars](https://img.shields.io/github/stars/csms-apply/csgrad)](https://github.com/csms-apply/csgrad)

--- a/i18n/en/docusaurus-plugin-content-docs/current/intro.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/intro.mdx
@@ -1,6 +1,6 @@
 ---
 id: intro
-title: North American MSCS Application Guide
+title: 'CS Grad: North American MSCS Application Guide'
 slug: /
 description: Compare North American CS, MSCS, and related master's programs using practical details on curriculum, cost, flexibility, admissions patterns, and career outcomes.
 hide_title: true
@@ -8,7 +8,7 @@ hide_title: true
 
 import VisitorGeoMap from '@site/src/components/VisitorGeoMap';
 
-# North American MSCS Application Guide
+# CS Grad: North American MSCS Application Guide
 
 <p><a href="https://csgrad.com/" hrefLang="zh-Hans" lang="zh-Hans">查看中文首页：北美 MSCS 申请指南</a></p>
 

--- a/i18n/zh-Hant/docusaurus-plugin-content-docs/current/intro.mdx
+++ b/i18n/zh-Hant/docusaurus-plugin-content-docs/current/intro.mdx
@@ -1,6 +1,6 @@
 ---
 id: intro
-title: 北美 MSCS 申請指南
+title: 'CS Grad: 北美MSCS 申請指南'
 slug: /
 description: CS Grad 提供北美 CS、MSCS 及相關碩士項目介紹、申請數據和選校參考，幫助申請者結合課程、成本與就業方向評估項目。
 hide_title: true
@@ -8,7 +8,7 @@ hide_title: true
 
 import VisitorGeoMap from '@site/src/components/VisitorGeoMap';
 
-# 北美 MSCS 申請指南 {#北美-mscs-申请指南}
+# CS Grad: 北美MSCS 申請指南 {#cs-grad-北美mscs-申请指南}
 
 ![License: CC BY-NC-SA 4.0](https://img.shields.io/badge/License-CC%20BY--NC--SA%204.0-lightgrey.svg)
 [![GitHub Repo stars](https://img.shields.io/github/stars/csms-apply/csgrad)](https://github.com/csms-apply/csgrad)

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test:analytics": "node --test src/lib/analytics/events.test.mjs",
     "test:migration": "node --test scripts/migration-integrity.test.mjs",
     "test:gpa-filter": "node --test src/lib/dp/gpa-filter.test.mjs",
-    "test:ux": "node --test scripts/locale-navigation.test.mjs src/lib/tracker/*.test.mjs src/lib/dp/page-regressions.test.mjs scripts/*positioning*.test.cjs"
+    "test:ux": "node --test scripts/locale-navigation.test.mjs src/lib/i18n/*.test.mjs src/lib/tracker/*.test.mjs src/lib/dp/page-regressions.test.mjs scripts/*positioning*.test.cjs"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/research/analytics/language-audience.md
+++ b/research/analytics/language-audience.md
@@ -1,0 +1,55 @@
+# 网站语言偏好与访问统计
+
+网站沿用现有 GA4，不新建用户身份，也不采集姓名、邮箱、申请资料或表单文本。
+语言偏好用于了解访问者选择的内容语言，不能据此推断国籍、族裔或申请背景。
+
+## 语言偏好行为
+
+用户点击语言选项时，即将该语言保存为默认语言。之后仅在访问未指定语言的根首页 `/` 时自动恢复偏好。
+明确指定语言的 `/en/`、`/zh-Hant/`，以及其他深链接，不会因保存的偏好而被强制跳转。
+
+## 事件
+
+统一由 `src/lib/analytics/events.mjs` 的 `trackSeoEvent` 发送：
+
+| 事件 | 含义 | 统计用途 |
+| --- | --- | --- |
+| `audience_visit` | 每次文档加载后的语言和偏好状态 | 按 `current_locale` 看实际阅读语言分布 |
+| `language_preference_set` | 用户手动选择默认语言 | 按 `selected_locale` 看主动选择分布 |
+| `language_preference_applied` | 已保存偏好自动跳转后，在目的页发送 | 观察默认语言功能的使用情况 |
+
+`audience_visit` 每次文档加载只发送一次，同一文档内的 SPA 页面切换不重复发送；刷新或重新打开页面可再次发送。
+不能把事件次数直接等同于独立访客人数。
+`language_preference_applied` 通过 `sessionStorage` 将自动跳转信息传递给目的页；若该存储不可用，应用事件可能缺失，但语言恢复功能仍可正常工作。
+比较访问者规模时使用 GA4 的用户指标；衡量操作次数时使用事件次数。
+
+## 有限参数
+
+| 参数 | 允许值 | 说明 |
+| --- | --- | --- |
+| `current_locale` | `zh-Hans` / `zh-Hant` / `en` | 必填，事件发生时的页面语言 |
+| `preferred_locale` | 三种语言 / `none` | 必填，保存的偏好；没有时为 `none` |
+| `preference_source` | `manual` / `saved` / `default` | 必填，手动选择 / 已保存偏好 / 未设置偏好 |
+| `selected_locale` | 三种语言 | 仅 `language_preference_set` 必填 |
+| `storage_status` | `persisted` / `unavailable` / `none` | 可选，已持久保存 / 存储不可用 / 尚无记录 |
+
+必填参数缺失或非法时整条事件不发送。其他字段全部丢弃，包括旧漏斗事件所允许的自由文本字段。
+这些事件使用 `transport_type: beacon`，尽量让切换页面前的选择事件完成发送；这不保证分析服务一定收到。
+这些事件的 `page_location` 和 `page_path` 均固定为对应语言首页，`page_referrer` 为空，覆盖 Docusaurus/GA4 全局页面地址，避免继承查询参数、片段或个人路径。
+这只约束新增语言事件，不改变现有 GA4 页面浏览和其他事件的采集规则。
+
+## GA4 查看方法
+
+在当前 GA4 资源中，为上述五个参数创建同名的**事件级自定义维度**。这需要 Editor 或更高权限；维度创建并开始收到事件后，报表通常需要 24–48 小时才能使用这些数据。参见 [Google 官方说明](https://support.google.com/analytics/answer/14239696)。
+
+推荐建立三个探索报表：
+
+1. 过滤 `event_name = audience_visit`，行选 `current_locale`，值选总用户数和事件数；用 `preferred_locale` 区分保存了偏好的访问者。
+2. 过滤 `event_name = language_preference_set`，行选 `selected_locale`，值选事件数；用 `storage_status` 检查偏好是否成功保存。
+3. 过滤 `event_name = language_preference_applied`，行选 `preferred_locale`，值选事件数，观察回访时自动应用语言的情况。
+
+这份代码改动不会自动创建 GA4 后台自定义维度。广告拦截、未加载分析脚本等情况可能导致少计；语言切换本身不依赖统计服务是否可用。
+
+## 本地验证
+
+运行 `npm run test:analytics`。测试验证三种语言、缺失/非法参数拒绝、自由文本与 URL 信息不会进入新增事件，并保留原有购买统计测试。

--- a/scripts/locale-navigation.test.mjs
+++ b/scripts/locale-navigation.test.mjs
@@ -4,6 +4,7 @@ import {createRequire} from 'node:module';
 import test from 'node:test';
 import {transformSync} from '@babel/core';
 import * as paths from '../src/lib/seo/localizedAlternates.mjs';
+import * as preferences from '../src/lib/i18n/preference.mjs';
 
 const require = createRequire(import.meta.url);
 const filename = new URL('../src/theme/NavbarItem/LocaleDropdownNavbarItem/index.js', import.meta.url);
@@ -34,6 +35,7 @@ function renderItems({pathname, search = '', hash = '', hydrated = true, querySt
     '@theme/NavbarItem/DropdownNavbarItem': () => null,
     '@theme/Icon/Language': () => null,
     '../../../lib/seo/localizedAlternates.mjs': paths,
+    '../../../lib/i18n/preference.mjs': preferences,
     './styles.module.css': {},
   };
   new Function('require', 'module', 'exports', code)(

--- a/src/lib/analytics/events.mjs
+++ b/src/lib/analytics/events.mjs
@@ -6,6 +6,9 @@ const ALLOWED_EVENTS = new Set([
   'begin_checkout',
   'experiment_exposure',
   'purchase',
+  'language_preference_set',
+  'language_preference_applied',
+  'audience_visit',
 ]);
 
 const ALLOWED_PARAMETERS = new Set([
@@ -22,6 +25,32 @@ const ALLOWED_PARAMETERS = new Set([
   'transaction_id',
   'items',
 ]);
+
+// Language analytics accepts only bounded categories, never caller-supplied text.
+const LANGUAGE_EVENTS = new Set([
+  'language_preference_set', 'language_preference_applied', 'audience_visit',
+]);
+const SUPPORTED_LOCALES = new Set(['zh-Hans', 'zh-Hant', 'en']);
+const LANGUAGE_PARAMETERS = {
+  current_locale: SUPPORTED_LOCALES,
+  selected_locale: SUPPORTED_LOCALES,
+  preferred_locale: new Set([...SUPPORTED_LOCALES, 'none']),
+  preference_source: new Set(['manual', 'saved', 'default']),
+  storage_status: new Set(['persisted', 'unavailable', 'none']),
+};
+
+function languagePayload(name, parameters) {
+  const payload = {};
+  for (const [key, allowed] of Object.entries(LANGUAGE_PARAMETERS)) {
+    if (allowed.has(parameters[key])) payload[key] = parameters[key];
+  }
+  if (!payload.current_locale || !payload.preferred_locale || !payload.preference_source) {
+    return null;
+  }
+  if (name === 'language_preference_set' && !payload.selected_locale) return null;
+  if (name !== 'language_preference_set') delete payload.selected_locale;
+  return payload;
+}
 
 const MAX_STRING_LENGTH = 100;
 const POSITIONING_ITEM_ID = 'school_positioning_report';
@@ -99,6 +128,20 @@ export function trackSeoEvent(name, parameters = {}, browserWindow = undefined) 
     ? (typeof window === 'undefined' ? null : window)
     : browserWindow;
   if (!target || typeof target.gtag !== 'function') return false;
+
+  if (LANGUAGE_EVENTS.has(name)) {
+    const payload = languagePayload(name, parameters || {});
+    if (!payload) return false;
+    // Override GA's default full URL: checkout/query/hash can contain private data.
+    // The locale-level page location is sufficient for this audience breakdown.
+    const localePath = payload.current_locale === 'zh-Hans' ? '/' : `/${payload.current_locale}/`;
+    payload.page_location = `https://csgrad.com${localePath}`;
+    payload.page_path = localePath;
+    payload.page_referrer = '';
+    payload.transport_type = 'beacon';
+    target.gtag('event', name, payload);
+    return true;
+  }
 
   const payload = {};
   for (const [key, value] of Object.entries(parameters || {})) {

--- a/src/lib/analytics/events.test.mjs
+++ b/src/lib/analytics/events.test.mjs
@@ -389,3 +389,85 @@ test('drops unsupported values and trims oversized strings', () => {
   assert.equal(payload.method.length, 100);
   assert.equal('content_group' in payload, false);
 });
+
+test('language analytics accepts all three locales and only bounded audience categories', () => {
+  const calls = [];
+  const browserWindow = {
+    gtag: (...args) => calls.push(args),
+    location: {pathname: '/private/person-name', search: '?email=private@example.com'},
+  };
+  for (const locale of ['zh-Hans', 'zh-Hant', 'en']) {
+    assert.equal(trackSeoEvent('language_preference_set', {
+      current_locale: locale,
+      selected_locale: 'en',
+      preferred_locale: 'en',
+      preference_source: 'manual',
+      storage_status: 'persisted',
+      email: 'private@example.com',
+      method: 'person-name',
+      page_type: 'private-profile',
+      page_location: 'https://example.com/private',
+      items: [{customer: 'private'}],
+    }, browserWindow), true);
+    assert.deepEqual(calls.at(-1)[2], {
+      current_locale: locale,
+      selected_locale: 'en',
+      preferred_locale: 'en',
+      preference_source: 'manual',
+      storage_status: 'persisted',
+      page_location: `https://csgrad.com${locale === 'zh-Hans' ? '/' : `/${locale}/`}`,
+      page_path: locale === 'zh-Hans' ? '/' : `/${locale}/`,
+      page_referrer: '',
+      transport_type: 'beacon',
+    });
+  }
+});
+
+test('language events reject missing or arbitrary required categories', () => {
+  const calls = [];
+  const browserWindow = {gtag: (...args) => calls.push(args)};
+  const valid = {current_locale: 'en', preferred_locale: 'none', preference_source: 'default'};
+  for (const name of ['audience_visit', 'language_preference_applied', 'language_preference_set']) {
+    for (const key of ['current_locale', 'preferred_locale', 'preference_source']) {
+      assert.equal(trackSeoEvent(name, {...valid, selected_locale: 'en', [key]: 'private@example.com'}, browserWindow), false);
+      assert.equal(trackSeoEvent(name, {...valid, selected_locale: 'en', [key]: undefined}, browserWindow), false);
+    }
+  }
+  assert.equal(trackSeoEvent('language_preference_set', valid, browserWindow), false);
+  assert.equal(trackSeoEvent('language_preference_set', {...valid, selected_locale: 'none'}, browserWindow), false);
+  assert.deepEqual(calls, []);
+});
+
+test('audience visits support unset preferences and discard invalid optional fields', () => {
+  const calls = [];
+  const browserWindow = {gtag: (...args) => calls.push(args)};
+  assert.equal(trackSeoEvent('audience_visit', {
+    current_locale: 'zh-Hant', preferred_locale: 'none', preference_source: 'default',
+    selected_locale: 'en', storage_status: 'private@example.com',
+  }, browserWindow), true);
+  assert.deepEqual(calls[0][2], {
+    current_locale: 'zh-Hant', preferred_locale: 'none', preference_source: 'default',
+    page_location: 'https://csgrad.com/zh-Hant/', page_path: '/zh-Hant/', page_referrer: '', transport_type: 'beacon',
+  });
+  assert.equal(trackSeoEvent('language_preference_applied', {
+    current_locale: 'en', preferred_locale: 'en', preference_source: 'saved', storage_status: 'persisted',
+  }, browserWindow), true);
+  assert.equal(calls.at(-1)[2].transport_type, 'beacon');
+});
+
+
+test('language events override globally inherited page paths containing query or hash data', () => {
+  const inherited = {
+    page_path: '/school-positioning-result?session_id=private#private-email',
+    page_location: 'https://csgrad.com/private?email=private@example.com',
+  };
+  const calls = [];
+  const browserWindow = {gtag: (_command, name, payload) => calls.push({name, ...inherited, ...payload})};
+  trackSeoEvent('audience_visit', {
+    current_locale: 'en', preferred_locale: 'en', preference_source: 'saved',
+    page_path: '/private-override',
+  }, browserWindow);
+  assert.equal(calls[0].page_path, '/en/');
+  assert.equal(calls[0].page_location, 'https://csgrad.com/en/');
+  assert.equal(JSON.stringify(calls).includes('private'), false);
+});

--- a/src/lib/i18n/preference.mjs
+++ b/src/lib/i18n/preference.mjs
@@ -1,0 +1,81 @@
+import {trackSeoEvent} from '../analytics/events.mjs';
+
+export const LANGUAGE_PREFERENCE_KEY = 'csgrad.preferred-language.v1';
+const APPLIED_KEY = 'csgrad.language-applied.v1';
+const LOCALES = new Set(['zh-Hans', 'zh-Hant', 'en']);
+const initialized = new WeakSet();
+
+export function readLanguagePreference(browser) {
+  try {
+    const locale = browser.localStorage.getItem(LANGUAGE_PREFERENCE_KEY);
+    return {locale: LOCALES.has(locale) ? locale : null, available: true};
+  } catch {
+    return {locale: null, available: false};
+  }
+}
+
+export function selectLanguage(locale, currentLocale, browser = window) {
+  if (!LOCALES.has(locale)) return false;
+  let persisted = false;
+  try {
+    browser.localStorage.setItem(LANGUAGE_PREFERENCE_KEY, locale);
+    persisted = browser.localStorage.getItem(LANGUAGE_PREFERENCE_KEY) === locale;
+  } catch {
+    // Navigation remains available in private/blocked storage environments.
+  }
+  trackSeoEvent('language_preference_set', {
+    current_locale: currentLocale,
+    selected_locale: locale,
+    preferred_locale: locale,
+    preference_source: 'manual',
+    storage_status: persisted ? 'persisted' : 'unavailable',
+  }, browser);
+  return persisted;
+}
+
+// Only the neutral homepage is an entry point for the saved default. Explicit
+// language URLs, shared documents and payment/auth callbacks retain their route.
+export function preferredHomepage(location, locale) {
+  if (location.pathname !== '/' || !LOCALES.has(locale) || locale === 'zh-Hans') return null;
+  return `/${locale}/${location.search || ''}${location.hash || ''}`;
+}
+
+export function initializeLanguagePreference(browser, currentLocale) {
+  if (initialized.has(browser)) return;
+  initialized.add(browser);
+  const {locale, available} = readLanguagePreference(browser);
+  const redirect = preferredHomepage(browser.location, locale);
+  if (redirect) {
+    try {
+      browser.sessionStorage.setItem(APPLIED_KEY, JSON.stringify({locale, time: Date.now()}));
+    } catch { /* Persistence of analytics is optional. */ }
+    browser.location.replace(redirect);
+    return;
+  }
+  const parameters = {
+    current_locale: currentLocale,
+    preferred_locale: locale || 'none',
+    preference_source: locale ? 'saved' : 'default',
+    storage_status: !available ? 'unavailable' : locale ? 'persisted' : 'none',
+  };
+  let applied = false;
+  try {
+    const pending = JSON.parse(browser.sessionStorage.getItem(APPLIED_KEY));
+    browser.sessionStorage.removeItem(APPLIED_KEY);
+    applied = pending?.locale === currentLocale && locale === currentLocale
+      && browser.location.pathname === `/${currentLocale}/`
+      && Number.isFinite(pending.time) && Date.now() >= pending.time
+      && Date.now() - pending.time < 60000;
+  } catch { /* Analytics should not affect page rendering. */ }
+  // The analytics script may load after hydration. Keep one bounded retry, and
+  // never block reading the page when analytics is blocked or unavailable.
+  let attempts = 0;
+  const send = () => {
+    if (trackSeoEvent('audience_visit', parameters, browser)) {
+      if (applied) trackSeoEvent('language_preference_applied', parameters, browser);
+    } else if (++attempts < 20) {
+      browser.setTimeout(send, 250);
+    }
+  };
+  send();
+}

--- a/src/lib/i18n/preference.test.mjs
+++ b/src/lib/i18n/preference.test.mjs
@@ -1,0 +1,93 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {LANGUAGE_PREFERENCE_KEY, selectLanguage, readLanguagePreference, preferredHomepage, initializeLanguagePreference} from './preference.mjs';
+
+function storage() {
+  const values = new Map();
+  return {getItem: key => values.get(key) ?? null, setItem: (key, value) => values.set(key, value), removeItem: key => values.delete(key)};
+}
+function browser(pathname = '/') {
+  const events = [], redirects = [], timers = [];
+  return {localStorage: storage(), sessionStorage: storage(),
+    location: {pathname, search: '?ref=example', hash: '#section', replace: url => redirects.push(url)},
+    gtag: (...args) => events.push(args), setTimeout: callback => timers.push(callback), events, redirects, timers};
+}
+
+test('manual selections persist all three defaults and emit bounded analytics', () => {
+  const b = browser();
+  for (const locale of ['en', 'zh-Hant', 'zh-Hans']) {
+    assert.equal(selectLanguage(locale, 'zh-Hans', b), true);
+    assert.equal(readLanguagePreference(b).locale, locale);
+    assert.equal(b.events.at(-1)[2].selected_locale, locale);
+  }
+  assert.equal(selectLanguage('https://evil.example', 'en', b), false);
+  assert.equal(b.events.length, 3);
+});
+
+test('only neutral homepage restores default, preserving search and hash', () => {
+  assert.equal(preferredHomepage(browser().location, 'en'), '/en/?ref=example#section');
+  assert.equal(preferredHomepage(browser().location, 'zh-Hant'), '/zh-Hant/?ref=example#section');
+  for (const path of ['/en/', '/zh-Hant/', '/datapoints', '/school-positioning-result', '/auth/callback']) {
+    assert.equal(preferredHomepage(browser(path).location, 'en'), null);
+  }
+  assert.equal(preferredHomepage(browser().location, 'zh-Hans'), null);
+  assert.equal(preferredHomepage(browser().location, 'bogus'), null);
+});
+
+test('revisit redirects once and records application only on destination', () => {
+  const source = browser();
+  selectLanguage('zh-Hant', 'zh-Hans', source);
+  source.events.length = 0;
+  initializeLanguagePreference(source, 'zh-Hans');
+  initializeLanguagePreference(source, 'zh-Hans');
+  assert.deepEqual(source.redirects, ['/zh-Hant/?ref=example#section']);
+  assert.equal(source.events.length, 0);
+  const destination = {...source, location: {...source.location, pathname: '/zh-Hant/'}};
+  initializeLanguagePreference(destination, 'zh-Hant');
+  initializeLanguagePreference(destination, 'zh-Hant');
+  assert.deepEqual(source.events.map(e => e[1]), ['audience_visit', 'language_preference_applied']);
+  assert.equal(source.events[0][2].current_locale, 'zh-Hant');
+  const nextVisit = {...destination};
+  initializeLanguagePreference(nextVisit, 'zh-Hant');
+  assert.equal(source.events.filter(e => e[1] === 'language_preference_applied').length, 1);
+});
+
+test('explicit links do not rewrite preference or force the saved language', () => {
+  const b = browser('/en/');
+  b.localStorage.setItem(LANGUAGE_PREFERENCE_KEY, 'zh-Hant');
+  initializeLanguagePreference(b, 'en');
+  assert.equal(b.redirects.length, 0);
+  assert.equal(readLanguagePreference(b).locale, 'zh-Hant');
+  assert.equal(b.events[0][2].current_locale, 'en');
+});
+
+test('blocked or corrupt storage never prevents use and never redirects externally', () => {
+  const b = browser();
+  Object.defineProperty(b, 'localStorage', {get() {throw new Error('denied');}});
+  Object.defineProperty(b, 'sessionStorage', {get() {throw new Error('denied');}});
+  assert.equal(selectLanguage('en', 'zh-Hans', b), false);
+  initializeLanguagePreference(b, 'zh-Hans');
+  assert.equal(b.redirects.length, 0);
+  assert.equal(b.events.at(-1)[2].storage_status, 'unavailable');
+  const invalid = browser();
+  invalid.localStorage.setItem(LANGUAGE_PREFERENCE_KEY, '//evil.example');
+  initializeLanguagePreference(invalid, 'zh-Hans');
+  assert.equal(invalid.redirects.length, 0);
+  assert.equal(invalid.events[0][2].preferred_locale, 'none');
+});
+
+test('delayed analytics emits once; blocked analytics retries are bounded', () => {
+  const b = browser();
+  delete b.gtag;
+  initializeLanguagePreference(b, 'zh-Hans');
+  assert.equal(b.timers.length, 1);
+  b.gtag = (...args) => b.events.push(args);
+  b.timers.shift()();
+  assert.equal(b.events.length, 1);
+  const blocked = browser();
+  delete blocked.gtag;
+  initializeLanguagePreference(blocked, 'zh-Hans');
+  let count = 0;
+  while (blocked.timers.length) {blocked.timers.shift()(); assert.ok(++count < 20);}
+  assert.equal(count, 19);
+});

--- a/src/theme/NavbarItem/LocaleDropdownNavbarItem/index.js
+++ b/src/theme/NavbarItem/LocaleDropdownNavbarItem/index.js
@@ -14,6 +14,7 @@ import useIsBrowser from '@docusaurus/useIsBrowser';
 import DropdownNavbarItem from '@theme/NavbarItem/DropdownNavbarItem';
 import IconLanguage from '@theme/Icon/Language';
 import {localizedAlternateUrl} from '../../../lib/seo/localizedAlternates.mjs';
+import {selectLanguage} from '../../../lib/i18n/preference.mjs';
 
 import styles from './styles.module.css';
 
@@ -56,6 +57,7 @@ export default function LocaleDropdownNavbarItem({
       to,
       target: '_self',
       autoAddBaseUrl: false,
+      onClick: () => selectLanguage(locale, currentLocale),
       className:
         locale === currentLocale
           ? mobile

--- a/src/theme/Root.js
+++ b/src/theme/Root.js
@@ -1,4 +1,6 @@
 import React, {useEffect} from 'react';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import {initializeLanguagePreference} from '@site/src/lib/i18n/preference.mjs';
 import {trackSeoEvent} from '@site/src/lib/analytics/events.mjs';
 import {copyTextWithFallback} from '@site/src/lib/analytics/clipboard.mjs';
 import {
@@ -32,6 +34,11 @@ function renderExperimentVariant(element, assignment) {
 }
 
 export default function Root({children}) {
+  const {i18n: {currentLocale}} = useDocusaurusContext();
+  useEffect(() => {
+    initializeLanguagePreference(window, currentLocale);
+  }, [currentLocale]);
+
   useEffect(() => {
     const supportsVisibilityTracking = typeof IntersectionObserver === 'function';
 


### PR DESCRIPTION
将首页标题更新为「CS Grad: 北美MSCS 申请指南」，并同步繁体和英文标题。用户点击语言菜单后会保存默认语言，以后进入根首页 `/` 自动恢复；菜单保持简洁，不显示记忆提示文字。

显式 `/en/`、`/zh-Hant/` 和其他深链接继续按 URL 显示，付款及登录回调路径不被重定向。语言切换保留查询条件和锚点；存储不可用时仍能正常切换。

增加 GA4 事件 `audience_visit`、`language_preference_set`、`language_preference_applied`，仅记录有限的语言和偏好状态枚举，并覆盖统计中的 URL/path/referrer，避免继承查询中的私人内容。统计说明见 `research/analytics/language-audience.md`；GA4 自定义维度需要在后台配置，语言分布不代表国籍。

验证：
- 三语言 production build 和 306 页 SEO 检查通过，无新增 SEO 问题。
- UX 74 项、analytics 23 项、繁体内容 5 项测试通过。
- 浏览器实测英文/繁体回访恢复、切回简体、显式英文深链接、台本筛选值保留，以及语言菜单无提示文字。
- 独立 review 已完成，发现的统计全局 page_path 继承问题已修复。

按要求仅提交 MR，等待审阅，不合并部署。
